### PR TITLE
Update fetch URL for publics in NovaCampanha

### DIFF
--- a/frontend-erp/src/modules/MarketingDigitalIA/pages/NovaCampanha.jsx
+++ b/frontend-erp/src/modules/MarketingDigitalIA/pages/NovaCampanha.jsx
@@ -14,7 +14,7 @@ function NovaCampanha() {
   useEffect(() => {
     const carregarPublicosAlvo = async () => {
       try {
-        const dados = await fetchComAuth('/publicos-alvo');
+        const dados = await fetchComAuth('/publicos');
         setPublicosAlvo(dados);
       } catch (err) {
         setErro('Erro ao carregar públicos-alvo: ' + err.message);


### PR DESCRIPTION
## Summary
- update `fetchComAuth` URL in `NovaCampanha.jsx`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test -- -u` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6851de537844832da0ff209c12cb23fa