### PR TITLE
Fix requirements for marketing IA backend

### DIFF
--- a/marketing-digital-ia/backend/requirements.txt
+++ b/marketing-digital-ia/backend/requirements.txt
@@ -2,3 +2,9 @@ fastapi
 uvicorn
 pydantic
 httpx
+python-dotenv
+openai
+Pillow
+requests
+faiss-cpu
+sentence-transformers


### PR DESCRIPTION
## Summary
- add missing deps for marketing digital IA backend

## Testing
- `python -m py_compile $(git ls-files '*.py' | grep -v 'marketing-digital-ia/backend/files')`

------
https://chatgpt.com/codex/tasks/task_e_6851e128db20832d805c6bdf861e78de