### PR TITLE
Make SECRET_KEY configurable

### DIFF
--- a/marketing-digital-ia/backend/services/auth_service.py
+++ b/marketing-digital-ia/backend/services/auth_service.py
@@ -5,7 +5,7 @@ from jose import jwt
 from datetime import datetime, timedelta
 
 # ⚙️ Configuração do JWT
-SECRET_KEY = "radha-super-secreto"  # Substitua por algo seguro em produção
+SECRET_KEY = os.getenv("SECRET_KEY", "radha-super-secreto")  # Use variável de ambiente
 ALGORITHM = "HS256"
 EXPIRATION_MINUTES = 60
 

--- a/rodar_ambientes.txt
+++ b/rodar_ambientes.txt
@@ -8,6 +8,7 @@
 cd /opt/radha/radha-erp/marketing-digital-ia/backend/
 # Ative o ambiente virtual
 source venv/bin/activate
+export SECRET_KEY=radha-super-secreto
 # Inicie o servidor FastAPI (deixe rodando)
 uvicorn main:app --host 0.0.0.0 --port 8015 --reload
 
@@ -16,6 +17,7 @@ uvicorn main:app --host 0.0.0.0 --port 8015 --reload
 cd /opt/radha/radha-erp/producao/backend/src/
 # Ative o ambiente virtual
 source venv/bin/activate
+export SECRET_KEY=radha-super-secreto
 # Inicie o servidor FastAPI (deixe rodando)
 uvicorn api:app --host 0.0.0.0 --port 8020 --reload
 
@@ -24,6 +26,7 @@ uvicorn api:app --host 0.0.0.0 --port 8020 --reload
 cd /opt/radha/radha-erp/backend-gateway/
 # Ative o ambiente virtual
 source venv/bin/activate
+export SECRET_KEY=radha-super-secreto
 # Inicie o servidor FastAPI (deixe rodando)
 uvicorn main:app --host 0.0.0.0 --port 8010 --reload
 

--- a/start_radha_erp.sh
+++ b/start_radha_erp.sh
@@ -7,6 +7,7 @@ RADHA_ERP_ROOT="/opt/radha/radha-erp"
 LOG_DIR="$RADHA_ERP_ROOT/logs"
 mkdir -p "$LOG_DIR" # Cria o diretório de logs se não existir
 
+export SECRET_KEY="${SECRET_KEY:-radha-super-secreto}"
 echo "=== Iniciando serviços do Radha ERP ===" | tee -a "$LOG_DIR/startup_main.log"
 echo "Data de início: $(date)" | tee -a "$LOG_DIR/startup_main.log"
 echo "Logs detalhados de cada serviço serão encontrados em $LOG_DIR" | tee -a "$LOG_DIR/startup_main.log"


### PR DESCRIPTION
## Summary
- read SECRET_KEY from env var in auth_service
- export SECRET_KEY in startup script
- document SECRET_KEY in manual startup guide

## Testing
- `pytest -q`
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6851e12e72f8832d8d0bc66625172cb0