### PR TITLE
Add barcode apontamento screen

### DIFF
--- a/frontend-erp/src/modules/Producao/AppProducao.jsx
+++ b/frontend-erp/src/modules/Producao/AppProducao.jsx
@@ -3,7 +3,8 @@ import { useNavigate, useParams } from "react-router-dom";
 import { Button } from "./components/ui/button"; 
 import ImportarXML from "./components/ImportarXML"; 
 import VisualizacaoPeca from "./components/VisualizacaoPeca"; 
-import Pacote from "./components/Pacote"; 
+import Pacote from "./components/Pacote";
+import Apontamento from "./components/Apontamento";
 import "./Producao.css";
 
 let globalIdProducao = parseInt(localStorage.getItem("globalPecaIdProducao")) || 1;
@@ -388,4 +389,4 @@ const EditarPecaProducao = () => {
 };
 
 // Reexporta os componentes para uso no index.jsx do módulo
-export { HomeProducao, LoteProducao, EditarPecaProducao, Pacote, ImportarXML, VisualizacaoPeca };
+export { HomeProducao, LoteProducao, EditarPecaProducao, Pacote, Apontamento, ImportarXML, VisualizacaoPeca };

--- a/frontend-erp/src/modules/Producao/components/Apontamento.jsx
+++ b/frontend-erp/src/modules/Producao/components/Apontamento.jsx
@@ -1,0 +1,85 @@
+import React, { useState } from "react";
+import { Button } from "./ui/button";
+
+const Apontamento = () => {
+  const lotes = JSON.parse(localStorage.getItem("lotesProducao") || "[]");
+  const [lote, setLote] = useState("");
+  const [pacoteIndex, setPacoteIndex] = useState("");
+  const [codigo, setCodigo] = useState("");
+  const [apontados, setApontados] = useState([]);
+
+  const pacotes = lote ? (lotes.find(l => l.nome === lote)?.pacotes || []) : [];
+  const pacote = pacotes[parseInt(pacoteIndex)] || null;
+
+  const registrarCodigo = (e) => {
+    e.preventDefault();
+    if (!pacote) return;
+    const cod = codigo.trim();
+    if (!cod) return;
+    const peca = pacote.pecas.find(p => String(p.codigo_peca) === cod);
+    if (peca) {
+      if (!apontados.includes(peca.id)) {
+        setApontados([...apontados, peca.id]);
+      }
+    } else {
+      alert("Código não encontrado no pacote");
+    }
+    setCodigo("");
+  };
+
+  return (
+    <div className="p-6">
+      <h2 className="text-lg font-semibold mb-4">Apontamento de Peças</h2>
+      <div className="flex flex-col sm:flex-row gap-2 mb-4">
+        <select
+          className="input sm:w-48"
+          value={lote}
+          onChange={e => { setLote(e.target.value); setPacoteIndex(""); setApontados([]); }}
+        >
+          <option value="">Selecione o Lote</option>
+          {lotes.map(l => (
+            <option key={l.nome} value={l.nome}>{l.nome}</option>
+          ))}
+        </select>
+        {pacotes.length > 0 && (
+          <select
+            className="input sm:w-48"
+            value={pacoteIndex}
+            onChange={e => { setPacoteIndex(e.target.value); setApontados([]); }}
+          >
+            <option value="">Selecione o Pacote</option>
+            {pacotes.map((p, i) => (
+              <option key={i} value={i}>{p.nome_pacote || `Pacote ${i + 1}`}</option>
+            ))}
+          </select>
+        )}
+      </div>
+      {pacote && (
+        <>
+          <form onSubmit={registrarCodigo} className="mb-4">
+            <input
+              className="input w-full sm:w-64"
+              placeholder="Program1 / Código de Barras"
+              value={codigo}
+              onChange={e => setCodigo(e.target.value)}
+              autoFocus
+            />
+          </form>
+          <ul className="space-y-1 max-h-96 overflow-y-auto">
+            {pacote.pecas.map(p => (
+              <li
+                key={p.id}
+                className={`border rounded p-2 ${apontados.includes(p.id) ? 'bg-green-200' : ''}`}
+              >
+                <span className="font-mono mr-2">{p.codigo_peca}</span>
+                {p.nome}
+              </li>
+            ))}
+          </ul>
+        </>
+      )}
+    </div>
+  );
+};
+
+export default Apontamento;

--- a/frontend-erp/src/modules/Producao/index.jsx
+++ b/frontend-erp/src/modules/Producao/index.jsx
@@ -2,13 +2,14 @@
 import React from 'react';
 import { Routes, Route, Link, Outlet, useResolvedPath, useMatch } from 'react-router-dom';
 // Importa os componentes renomeados do AppProducao.jsx
-import { HomeProducao, LoteProducao, EditarPecaProducao, Pacote } from './AppProducao';
+import { HomeProducao, LoteProducao, EditarPecaProducao, Pacote, Apontamento } from './AppProducao';
 
 function ProducaoLayout() {
   const resolved = useResolvedPath(''); // O caminho base para este módulo
   const matchHome = useMatch(`${resolved.pathname}`); // Matches /producao exactly
   // Para o link "Início Produção" ser ativo quando estiver na raiz do módulo
   const matchLote = useMatch(`${resolved.pathname}/lote/*`); // Matches /producao/lote/qualquer_nome
+  const matchApontamento = useMatch(`${resolved.pathname}/apontamento`);
 
   return (
     <div className="p-4 bg-white rounded shadow-md">
@@ -19,6 +20,12 @@ function ProducaoLayout() {
           className={`px-3 py-1 rounded ${matchHome ? 'bg-blue-200 text-blue-800' : 'text-blue-600 hover:bg-blue-100'}`}
         >
           Início Produção
+        </Link>
+        <Link
+          to="apontamento"
+          className={`px-3 py-1 rounded ${matchApontamento ? 'bg-blue-200 text-blue-800' : 'text-blue-600 hover:bg-blue-100'}`}
+        >
+          Apontamento
         </Link>
         {/* Adicionar mais links de navegação interna do módulo, se necessário */}
       </nav>
@@ -35,6 +42,7 @@ function Producao() {
         <Route path="lote/:nome" element={<LoteProducao />} />
         <Route path="lote/:nome/pacote/:indice" element={<Pacote />} />
         <Route path="lote/:nome/peca/:peca" element={<EditarPecaProducao />} />
+        <Route path="apontamento" element={<Apontamento />} />
       </Route>
     </Routes>
   );


### PR DESCRIPTION
## Summary
- add Apontamento page to choose lote and pacote
- keep list visible and highlight scanned pieces
- wire new page into Producao module navigation

## Testing
- `npm run lint` *(fails: Invalid option '--ext')*


------
https://chatgpt.com/codex/tasks/task_e_6851f3068854832da3705bcf9f3448d8