### PR TITLE
Add volume apontamento screen

### DIFF
--- a/frontend-erp/package-lock.json
+++ b/frontend-erp/package-lock.json
@@ -20,6 +20,7 @@
         "tailwindcss-animate": "^1.0.7"
       },
       "devDependencies": {
+        "@eslint/js": "^9.29.0",
         "@types/react": "^18.2.64",
         "@types/react-dom": "^18.2.21",
         "@vitejs/plugin-react": "^4.5.0",
@@ -739,12 +740,16 @@
       }
     },
     "node_modules/@eslint/js": {
-      "version": "8.57.1",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.57.1.tgz",
-      "integrity": "sha512-d9zaMRSTIKDLhctzH12MtXvJKSSUhaHcjV+2Z+GK+EEY7XKpP5yR4x+N3TAcHTcu963nIr+TMcCb4DBCYX1z6Q==",
+      "version": "9.29.0",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.29.0.tgz",
+      "integrity": "sha512-3PIF4cBw/y+1u2EazflInpV+lYsSG0aByVIQzAgb1m1MhHFSbqTyNqtBKHgWf/9Ykud+DhILS9EGkmekVhbKoQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
       }
     },
     "node_modules/@humanwhocodes/config-array": {
@@ -2406,6 +2411,16 @@
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint/node_modules/@eslint/js": {
+      "version": "8.57.1",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.57.1.tgz",
+      "integrity": "sha512-d9zaMRSTIKDLhctzH12MtXvJKSSUhaHcjV+2Z+GK+EEY7XKpP5yR4x+N3TAcHTcu963nIr+TMcCb4DBCYX1z6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
     },
     "node_modules/espree": {

--- a/frontend-erp/package.json
+++ b/frontend-erp/package.json
@@ -6,32 +6,33 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "lint": "eslint . --ext js,jsx --report-unused-disable-directives --max-warnings 0",
+    "lint": "eslint . --report-unused-disable-directives --max-warnings 0",
     "preview": "vite preview"
   },
   "dependencies": {
-    "react": "^18.2.0",
-    "react-dom": "^18.2.0",
-    "react-router-dom": "^6.23.0",
     "@radix-ui/react-slot": "^1.2.3",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "lucide-react": "^0.511.0",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "react-router-dom": "^6.23.0",
     "tailwind-merge": "^3.3.0",
     "tailwind-variants": "^1.0.0",
     "tailwindcss-animate": "^1.0.7"
   },
   "devDependencies": {
+    "@eslint/js": "^9.29.0",
     "@types/react": "^18.2.64",
     "@types/react-dom": "^18.2.21",
     "@vitejs/plugin-react": "^4.5.0",
+    "autoprefixer": "^10.4.0",
     "eslint": "^8.57.0",
     "eslint-plugin-react": "^7.34.0",
     "eslint-plugin-react-hooks": "^4.6.0",
     "eslint-plugin-react-refresh": "^0.4.5",
-    "vite": "^5.0.0",
-    "autoprefixer": "^10.4.0",
     "postcss": "^8.4.0",
-    "tailwindcss": "^3.3.0"
+    "tailwindcss": "^3.3.0",
+    "vite": "^5.0.0"
   }
 }

--- a/frontend-erp/src/modules/Producao/AppProducao.jsx
+++ b/frontend-erp/src/modules/Producao/AppProducao.jsx
@@ -3,7 +3,9 @@ import { useNavigate, useParams } from "react-router-dom";
 import { Button } from "./components/ui/button"; 
 import ImportarXML from "./components/ImportarXML"; 
 import VisualizacaoPeca from "./components/VisualizacaoPeca"; 
-import Pacote from "./components/Pacote"; 
+import Pacote from "./components/Pacote";
+import Apontamento from "./components/Apontamento";
+import ApontamentoVolume from "./components/ApontamentoVolume";
 import "./Producao.css";
 
 let globalIdProducao = parseInt(localStorage.getItem("globalPecaIdProducao")) || 1;
@@ -388,4 +390,4 @@ const EditarPecaProducao = () => {
 };
 
 // Reexporta os componentes para uso no index.jsx do módulo
-export { HomeProducao, LoteProducao, EditarPecaProducao, Pacote, ImportarXML, VisualizacaoPeca };
+export { HomeProducao, LoteProducao, EditarPecaProducao, Pacote, Apontamento, ApontamentoVolume, ImportarXML, VisualizacaoPeca };

--- a/frontend-erp/src/modules/Producao/components/Apontamento.jsx
+++ b/frontend-erp/src/modules/Producao/components/Apontamento.jsx
@@ -1,0 +1,85 @@
+import React, { useState } from "react";
+import { Button } from "./ui/button";
+
+const Apontamento = () => {
+  const lotes = JSON.parse(localStorage.getItem("lotesProducao") || "[]");
+  const [lote, setLote] = useState("");
+  const [pacoteIndex, setPacoteIndex] = useState("");
+  const [codigo, setCodigo] = useState("");
+  const [apontados, setApontados] = useState([]);
+
+  const pacotes = lote ? (lotes.find(l => l.nome === lote)?.pacotes || []) : [];
+  const pacote = pacotes[parseInt(pacoteIndex)] || null;
+
+  const registrarCodigo = (e) => {
+    e.preventDefault();
+    if (!pacote) return;
+    const cod = codigo.trim();
+    if (!cod) return;
+    const peca = pacote.pecas.find(p => String(p.codigo_peca) === cod);
+    if (peca) {
+      if (!apontados.includes(peca.id)) {
+        setApontados([...apontados, peca.id]);
+      }
+    } else {
+      alert("Código não encontrado no pacote");
+    }
+    setCodigo("");
+  };
+
+  return (
+    <div className="p-6">
+      <h2 className="text-lg font-semibold mb-4">Apontamento de Peças</h2>
+      <div className="flex flex-col sm:flex-row gap-2 mb-4">
+        <select
+          className="input sm:w-48"
+          value={lote}
+          onChange={e => { setLote(e.target.value); setPacoteIndex(""); setApontados([]); }}
+        >
+          <option value="">Selecione o Lote</option>
+          {lotes.map(l => (
+            <option key={l.nome} value={l.nome}>{l.nome}</option>
+          ))}
+        </select>
+        {pacotes.length > 0 && (
+          <select
+            className="input sm:w-48"
+            value={pacoteIndex}
+            onChange={e => { setPacoteIndex(e.target.value); setApontados([]); }}
+          >
+            <option value="">Selecione o Pacote</option>
+            {pacotes.map((p, i) => (
+              <option key={i} value={i}>{p.nome_pacote || `Pacote ${i + 1}`}</option>
+            ))}
+          </select>
+        )}
+      </div>
+      {pacote && (
+        <>
+          <form onSubmit={registrarCodigo} className="mb-4">
+            <input
+              className="input w-full sm:w-64"
+              placeholder="Program1 / Código de Barras"
+              value={codigo}
+              onChange={e => setCodigo(e.target.value)}
+              autoFocus
+            />
+          </form>
+          <ul className="space-y-1 max-h-96 overflow-y-auto">
+            {pacote.pecas.map(p => (
+              <li
+                key={p.id}
+                className={`border rounded p-2 ${apontados.includes(p.id) ? 'bg-green-200' : ''}`}
+              >
+                <span className="font-mono mr-2">{p.codigo_peca}</span>
+                {p.nome}
+              </li>
+            ))}
+          </ul>
+        </>
+      )}
+    </div>
+  );
+};
+
+export default Apontamento;

--- a/frontend-erp/src/modules/Producao/components/ApontamentoVolume.jsx
+++ b/frontend-erp/src/modules/Producao/components/ApontamentoVolume.jsx
@@ -1,0 +1,151 @@
+import React, { useState } from "react";
+import { Button } from "./ui/button";
+
+const gerarCodigoVolume = () => {
+  const atual = parseInt(localStorage.getItem("globalVolumeId") || "1");
+  localStorage.setItem("globalVolumeId", atual + 1);
+  return `VOL${String(atual).padStart(6, "0")}`;
+};
+
+const ApontamentoVolume = () => {
+  const lotes = JSON.parse(localStorage.getItem("lotesProducao") || "[]");
+  const [lote, setLote] = useState("");
+  const [pacoteIndex, setPacoteIndex] = useState("");
+  const [codigo, setCodigo] = useState("");
+  const [emVolume, setEmVolume] = useState([]);
+  const pacotes = lote ? (lotes.find(l => l.nome === lote)?.pacotes || []) : [];
+  const pacote = pacotes[parseInt(pacoteIndex)] || null;
+  const [volumes, setVolumes] = useState(() => pacote?.volumes || []);
+
+  const salvarVolumes = novos => {
+    const lotesAtualizados = lotes.map(l => {
+      if (l.nome !== lote) return l;
+      return {
+        ...l,
+        pacotes: l.pacotes.map((p, i) =>
+          i !== parseInt(pacoteIndex) ? p : { ...p, volumes: novos }
+        ),
+      };
+    });
+    localStorage.setItem("lotesProducao", JSON.stringify(lotesAtualizados));
+  };
+
+  const registrarCodigo = e => {
+    e.preventDefault();
+    if (!pacote) return;
+    const cod = codigo.trim();
+    if (!cod) return;
+
+    if (cod === "999999") {
+      if (emVolume.length > 0) {
+        const codigoVolume = gerarCodigoVolume();
+        const novo = { codigo: codigoVolume, pecas: emVolume };
+        const novos = [...volumes, novo];
+        setVolumes(novos);
+        salvarVolumes(novos);
+        setEmVolume([]);
+      }
+    } else {
+      const peca = pacote.pecas.find(p => String(p.codigo_peca) === cod);
+      if (peca) {
+        if (!emVolume.includes(peca.id) && !volumes.some(v => v.pecas.includes(peca.id))) {
+          setEmVolume([...emVolume, peca.id]);
+        }
+      } else {
+        alert("Código não encontrado no pacote");
+      }
+    }
+    setCodigo("");
+  };
+
+  const pecasMarcadas = new Set([
+    ...emVolume,
+    ...volumes.flatMap(v => v.pecas),
+  ]);
+
+  return (
+    <div className="p-6">
+      <h2 className="text-lg font-semibold mb-4">Apontamento de Volumes</h2>
+      <div className="flex flex-col sm:flex-row gap-2 mb-4">
+        <select
+          className="input sm:w-48"
+          value={lote}
+          onChange={e => {
+            setLote(e.target.value);
+            setPacoteIndex("");
+            setEmVolume([]);
+            setVolumes([]);
+          }}
+        >
+          <option value="">Selecione o Lote</option>
+          {lotes.map(l => (
+            <option key={l.nome} value={l.nome}>{l.nome}</option>
+          ))}
+        </select>
+        {pacotes.length > 0 && (
+          <select
+            className="input sm:w-48"
+            value={pacoteIndex}
+            onChange={e => {
+              setPacoteIndex(e.target.value);
+              const p = pacotes[parseInt(e.target.value)];
+              setVolumes(p?.volumes || []);
+              setEmVolume([]);
+            }}
+          >
+            <option value="">Selecione o Pacote</option>
+            {pacotes.map((p, i) => (
+              <option key={i} value={i}>{p.nome_pacote || `Pacote ${i + 1}`}</option>
+            ))}
+          </select>
+        )}
+      </div>
+      {pacote && (
+        <>
+          <form onSubmit={registrarCodigo} className="mb-4">
+            <input
+              className="input w-full sm:w-64"
+              placeholder="Código de Barras"
+              value={codigo}
+              onChange={e => setCodigo(e.target.value)}
+              autoFocus
+            />
+          </form>
+          <div className="flex flex-col md:flex-row gap-4">
+            <ul className="space-y-1 max-h-96 overflow-y-auto flex-grow">
+              {pacote.pecas.map(p => (
+                <li
+                  key={p.id}
+                  className={`border rounded p-2 ${pecasMarcadas.has(p.id) ? 'bg-green-200' : ''}`}
+                >
+                  <span className="font-mono mr-2">{p.codigo_peca}</span>
+                  {p.nome}
+                </li>
+              ))}
+            </ul>
+            <div className="flex-shrink-0 w-full md:w-64">
+              <h3 className="font-semibold mb-2">Volumes</h3>
+              <ul className="space-y-2 max-h-96 overflow-y-auto">
+                {volumes.map((v, idx) => (
+                  <li key={idx} className="border rounded p-2">
+                    <div className="font-medium">Volume {idx + 1} - <span className="font-mono">{v.codigo}</span></div>
+                    <ul className="list-disc ml-4">
+                      {v.pecas.map(id => {
+                        const pc = pacote.pecas.find(p => p.id === id);
+                        return pc ? (
+                          <li key={id}>{pc.nome} ({pc.codigo_peca})</li>
+                        ) : null;
+                      })}
+                    </ul>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          </div>
+        </>
+      )}
+    </div>
+  );
+};
+
+export default ApontamentoVolume;

--- a/frontend-erp/src/modules/Producao/index.jsx
+++ b/frontend-erp/src/modules/Producao/index.jsx
@@ -2,13 +2,13 @@
 import React from 'react';
 import { Routes, Route, Link, Outlet, useResolvedPath, useMatch } from 'react-router-dom';
 // Importa os componentes renomeados do AppProducao.jsx
-import { HomeProducao, LoteProducao, EditarPecaProducao, Pacote } from './AppProducao';
+import { HomeProducao, LoteProducao, EditarPecaProducao, Pacote, Apontamento, ApontamentoVolume } from './AppProducao';
 
 function ProducaoLayout() {
   const resolved = useResolvedPath(''); // O caminho base para este módulo
   const matchHome = useMatch(`${resolved.pathname}`); // Matches /producao exactly
-  // Para o link "Início Produção" ser ativo quando estiver na raiz do módulo
-  const matchLote = useMatch(`${resolved.pathname}/lote/*`); // Matches /producao/lote/qualquer_nome
+  const matchApontamento = useMatch(`${resolved.pathname}/apontamento`);
+  const matchVolume = useMatch(`${resolved.pathname}/volumes`);
 
   return (
     <div className="p-4 bg-white rounded shadow-md">
@@ -19,6 +19,18 @@ function ProducaoLayout() {
           className={`px-3 py-1 rounded ${matchHome ? 'bg-blue-200 text-blue-800' : 'text-blue-600 hover:bg-blue-100'}`}
         >
           Início Produção
+        </Link>
+        <Link
+          to="apontamento"
+          className={`px-3 py-1 rounded ${matchApontamento ? 'bg-blue-200 text-blue-800' : 'text-blue-600 hover:bg-blue-100'}`}
+        >
+          Apontamento
+        </Link>
+        <Link
+          to="volumes"
+          className={`px-3 py-1 rounded ${matchVolume ? 'bg-blue-200 text-blue-800' : 'text-blue-600 hover:bg-blue-100'}`}
+        >
+          Volumes
         </Link>
         {/* Adicionar mais links de navegação interna do módulo, se necessário */}
       </nav>
@@ -35,6 +47,8 @@ function Producao() {
         <Route path="lote/:nome" element={<LoteProducao />} />
         <Route path="lote/:nome/pacote/:indice" element={<Pacote />} />
         <Route path="lote/:nome/peca/:peca" element={<EditarPecaProducao />} />
+        <Route path="apontamento" element={<Apontamento />} />
+        <Route path="volumes" element={<ApontamentoVolume />} />
       </Route>
     </Routes>
   );


### PR DESCRIPTION
## Summary
- add ApontamentoVolume page for closing volumes via code 999999
- wire new page into Producao module navigation and routing
- export ApontamentoVolume from AppProducao
- install @eslint/js and fix lint script

## Testing
- `npm run lint` *(fails: '__dirname' is not defined, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6851f3068854832da3705bcf9f3448d8