### PR TITLE
Add Node globals for config files

### DIFF
--- a/frontend-erp/eslint.config.js
+++ b/frontend-erp/eslint.config.js
@@ -30,4 +30,14 @@ export default [
       ],
     },
   },
+  {
+    files: [
+      '**/vite.config.{js,cjs,mjs,ts}',
+      '**/postcss.config.{js,cjs,mjs,ts}',
+      '**/tailwind.config.{js,cjs,mjs,ts}',
+    ],
+    languageOptions: {
+      globals: globals.node,
+    },
+  },
 ]


### PR DESCRIPTION
## Summary
- enable Node globals for Vite/Tailwind/PostCSS config files in ESLint

## Testing
- `npm run lint` *(fails: Invalid option `--ext` with flat config)*
- `npx eslint .`

------
https://chatgpt.com/codex/tasks/task_e_68520d600e7c832d91e0594b07c08a5d