### PR TITLE
Fix Vite module entry for Producao

### DIFF
--- a/frontend-erp/src/modules/Producao/package.json
+++ b/frontend-erp/src/modules/Producao/package.json
@@ -1,5 +1,6 @@
 {
   "name": "painel-radha",
+  "main": "index.jsx",
   "version": "1.0.0",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## Summary
- specify entrypoint for Producao module

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_685348d43ba0832da3a247271136dfbe