### PR TITLE
Fix API base URL configuration

### DIFF
--- a/frontend-erp/.env.example
+++ b/frontend-erp/.env.example
@@ -1,0 +1,1 @@
+VITE_GATEWAY_URL=http://localhost:8010

--- a/frontend-erp/src/App.jsx
+++ b/frontend-erp/src/App.jsx
@@ -55,7 +55,7 @@ function App() {
       const token = localStorage.getItem("token");
       if (token) {
         try {
-          const dados = await fetchComAuth("http://localhost:8010/auth/validate");
+          const dados = await fetchComAuth("/auth/validate");
           setUsuarioLogado(dados.usuario);
         } catch (error) {
           console.error("Token inválido ou expirado, fazendo logout.", error);

--- a/frontend-erp/src/modules/Producao/AppProducao.jsx
+++ b/frontend-erp/src/modules/Producao/AppProducao.jsx
@@ -1,8 +1,9 @@
 import React, { useState, useEffect } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 import { Button } from "./components/ui/button"; 
-import ImportarXML from "./components/ImportarXML"; 
-import VisualizacaoPeca from "./components/VisualizacaoPeca"; 
+import ImportarXML from "./components/ImportarXML";
+import VisualizacaoPeca from "./components/VisualizacaoPeca";
+import { fetchComAuth } from "../../utils/fetchComAuth";
 import Pacote from "./components/Pacote";
 import Apontamento from "./components/Apontamento";
 import ApontamentoVolume from "./components/ApontamentoVolume";
@@ -98,12 +99,10 @@ const LoteProducao = () => {
       ...pc,
       operacoes: JSON.parse(localStorage.getItem("op_producao_" + pc.id) || "[]")
     })));
-    const resposta = await fetch("http://localhost:8010/producao/gerar-lote-final", {
+    const json = await fetchComAuth("/producao/gerar-lote-final", {
       method: "POST",
-      headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ lote: nome, pecas })
     });
-    const json = await resposta.json();
     alert(json.mensagem);
   };
 

--- a/frontend-erp/src/modules/Producao/components/ImportarXML.jsx
+++ b/frontend-erp/src/modules/Producao/components/ImportarXML.jsx
@@ -23,7 +23,7 @@ const ImportarXML = ({ onImportarPacote }) => {
 
     try {
       // URL completa apontando para o gateway, que redirecionará para o backend de produção
-      const data = await fetchComAuth("http://localhost:8010/producao/importar-xml", {
+      const data = await fetchComAuth("/producao/importar-xml", {
         method: "POST",
         body: formData,
         // Não é mais necessário definir headers aqui, fetchComAuth cuidará disso.

--- a/frontend-erp/src/pages/Login.jsx
+++ b/frontend-erp/src/pages/Login.jsx
@@ -1,4 +1,5 @@
 import React, { useState } from "react";
+import { fetchComAuth } from "../utils/fetchComAuth";
 
 // Recebe a função `onLoginSuccess` como propriedade
 function Login({ onLoginSuccess }) {
@@ -16,18 +17,10 @@ function Login({ onLoginSuccess }) {
     }
 
     try {
-      const response = await fetch("http://localhost:8010/auth/login", {
+      const data = await fetchComAuth("/auth/login", {
         method: "POST",
-        headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ username, password }),
       });
-
-      if (!response.ok) {
-        const erroData = await response.json();
-        throw new Error(erroData.detail || "Falha no login");
-      }
-
-      const data = await response.json();
       localStorage.setItem("token", data.access_token);
       
       // Chama a função do componente pai (App.jsx) para atualizar o estado e navegar

--- a/frontend-erp/src/utils/fetchComAuth.js
+++ b/frontend-erp/src/utils/fetchComAuth.js
@@ -1,3 +1,5 @@
+const GATEWAY_URL = import.meta.env.VITE_GATEWAY_URL || "http://localhost:8010";
+
 export async function fetchComAuth(url, options = {}) {
   const token = localStorage.getItem("token");
 
@@ -17,16 +19,19 @@ export async function fetchComAuth(url, options = {}) {
   // --- LÓGICA DE PREFIXO DE URL RESTAURADA E AJUSTADA ---
   let finalUrl = url;
   if (url.startsWith('/')) { // Se for uma rota relativa
-      if (url.startsWith('/publicos') || url.startsWith('/nova-campanha') || url.startsWith('/nova-publicacao') || url.startsWith('/chat') || url.startsWith('/conhecimento') || url.startsWith('/auth')) {
-          finalUrl = `http://localhost:8010/marketing-ia${url}`; // Rotas do Marketing Digital IA via Gateway
+      if (url.startsWith('/publicos') || url.startsWith('/nova-campanha') || url.startsWith('/nova-publicacao') || url.startsWith('/chat') || url.startsWith('/conhecimento')) {
+          finalUrl = `${GATEWAY_URL}/marketing-ia${url}`; // Rotas do Marketing Digital IA via Gateway
       } else if (url.startsWith('/importar-xml') || url.startsWith('/gerar-lote-final')) {
-          finalUrl = `http://localhost:8010/producao${url}`; // Rotas de Produção via Gateway
+          finalUrl = `${GATEWAY_URL}/producao${url}`; // Rotas de Produção via Gateway
+      } else if (url.startsWith('/auth')) {
+          finalUrl = `${GATEWAY_URL}${url}`; // Endpoints de autenticação direto no Gateway
       }
   } else {
     // Se a URL já for absoluta e não começar com a porta do gateway, precisamos ajustá-la
     // Isso é uma proteção caso alguma chamada no futuro não use a lógica relativa
     if (url.includes("localhost:8000") || url.includes("localhost:8005") || url.includes("localhost:8009")) {
-        finalUrl = url.replace(/localhost:(8000|8005|8009)/, "localhost:8010");
+        const gatewayHost = GATEWAY_URL.replace(/^https?:\/\//, '');
+        finalUrl = url.replace(/localhost:(8000|8005|8009)/, gatewayHost);
     }
   }
   // --- FIM DA LÓGICA DE PREFIXO DE URL ---


### PR DESCRIPTION
## Summary
- support custom gateway URL via environment variable
- update API calls to use relative paths
- provide example .env file

## Testing
- `npm run lint` *(fails: Invalid option '--ext' when using eslint.config.js)*

------
https://chatgpt.com/codex/tasks/task_e_685351010f98832d8901b98bc500790a