### PR TITLE
Add package filter to production pointing screens

### DIFF
--- a/frontend-erp/src/modules/Producao/components/Apontamento.jsx
+++ b/frontend-erp/src/modules/Producao/components/Apontamento.jsx
@@ -1,5 +1,6 @@
 import React, { useState } from "react";
 import { Button } from "./ui/button";
+import FiltroPacote from "./FiltroPacote";
 
 const Apontamento = () => {
   const lotes = JSON.parse(localStorage.getItem("lotesProducao") || "[]");
@@ -30,30 +31,14 @@ const Apontamento = () => {
   return (
     <div className="p-6">
       <h2 className="text-lg font-semibold mb-4">Apontamento de Peças</h2>
-      <div className="flex flex-col sm:flex-row gap-2 mb-4">
-        <select
-          className="input sm:w-48"
-          value={lote}
-          onChange={e => { setLote(e.target.value); setPacoteIndex(""); setApontados([]); }}
-        >
-          <option value="">Selecione o Lote</option>
-          {lotes.map(l => (
-            <option key={l.nome} value={l.nome}>{l.nome}</option>
-          ))}
-        </select>
-        {pacotes.length > 0 && (
-          <select
-            className="input sm:w-48"
-            value={pacoteIndex}
-            onChange={e => { setPacoteIndex(e.target.value); setApontados([]); }}
-          >
-            <option value="">Selecione o Pacote</option>
-            {pacotes.map((p, i) => (
-              <option key={i} value={i}>{p.nome_pacote || `Pacote ${i + 1}`}</option>
-            ))}
-          </select>
-        )}
-      </div>
+      <FiltroPacote
+        lotes={lotes}
+        lote={lote}
+        onChangeLote={(v) => { setLote(v); setPacoteIndex(""); setApontados([]); }}
+        pacotes={pacotes}
+        pacoteIndex={pacoteIndex}
+        onChangePacote={(v) => { setPacoteIndex(v); setApontados([]); }}
+      />
       {pacote && (
         <>
           <form onSubmit={registrarCodigo} className="mb-4">

--- a/frontend-erp/src/modules/Producao/components/ApontamentoVolume.jsx
+++ b/frontend-erp/src/modules/Producao/components/ApontamentoVolume.jsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from "react";
 import JsBarcode from "jsbarcode";
+import FiltroPacote from "./FiltroPacote";
 
 const CODE_FECHA_VOLUME = "999999";
 
@@ -88,30 +89,14 @@ const gerarCodigoBarra = (num) => {
   return (
     <div className="p-6">
       <h2 className="text-lg font-semibold mb-4">Apontamento de Volumes</h2>
-      <div className="flex flex-col sm:flex-row gap-2 mb-4">
-        <select
-          className="input sm:w-48"
-          value={lote}
-          onChange={e => { setLote(e.target.value); setPacoteIndex(""); }}
-        >
-          <option value="">Selecione o Lote</option>
-          {lotes.map(l => (
-            <option key={l.nome} value={l.nome}>{l.nome}</option>
-          ))}
-        </select>
-        {pacotes.length > 0 && (
-          <select
-            className="input sm:w-48"
-            value={pacoteIndex}
-            onChange={e => setPacoteIndex(e.target.value)}
-          >
-            <option value="">Selecione o Pacote</option>
-            {pacotes.map((p, i) => (
-              <option key={i} value={i}>{p.nome_pacote || `Pacote ${i + 1}`}</option>
-            ))}
-          </select>
-        )}
-      </div>
+      <FiltroPacote
+        lotes={lotes}
+        lote={lote}
+        onChangeLote={(v) => { setLote(v); setPacoteIndex(""); }}
+        pacotes={pacotes}
+        pacoteIndex={pacoteIndex}
+        onChangePacote={(v) => setPacoteIndex(v)}
+      />
       {pacote && (
         <>
           <form onSubmit={registrarCodigo} className="mb-4">

--- a/frontend-erp/src/modules/Producao/components/FiltroPacote.jsx
+++ b/frontend-erp/src/modules/Producao/components/FiltroPacote.jsx
@@ -1,0 +1,32 @@
+import React from "react";
+
+const FiltroPacote = ({ lotes, lote, onChangeLote, pacotes, pacoteIndex, onChangePacote }) => {
+  return (
+    <div className="flex flex-col sm:flex-row gap-2 mb-4">
+      <select
+        className="input sm:w-48"
+        value={lote}
+        onChange={e => onChangeLote(e.target.value)}
+      >
+        <option value="">Selecione o Lote</option>
+        {lotes.map(l => (
+          <option key={l.nome} value={l.nome}>{l.nome}</option>
+        ))}
+      </select>
+      {pacotes.length > 0 && (
+        <select
+          className="input sm:w-48"
+          value={pacoteIndex}
+          onChange={e => onChangePacote(e.target.value)}
+        >
+          <option value="">Selecione o Pacote</option>
+          {pacotes.map((p, i) => (
+            <option key={i} value={i}>{p.nome_pacote || `Pacote ${i + 1}`}</option>
+          ))}
+        </select>
+      )}
+    </div>
+  );
+};
+
+export default FiltroPacote;


### PR DESCRIPTION
## Summary
- add reusable `FiltroPacote` component for selecting lot and package
- use new selector in `Apontamento` and `ApontamentoVolume` screens

## Testing
- `npm install`
- `npm run lint` *(fails: Invalid option '--ext')*

------
https://chatgpt.com/codex/tasks/task_e_68535d915c58832dbc5a38892f09183f