### PR TITLE
Fix Marketing IA frontend endpoints

### DIFF
--- a/frontend-erp/src/modules/MarketingDigitalIA/pages/Chat.jsx
+++ b/frontend-erp/src/modules/MarketingDigitalIA/pages/Chat.jsx
@@ -24,9 +24,9 @@ function Chat({ usuarioLogado }) {
 
     try {
       // CORRIGIDO: Removido usuarioLogado.token da chamada, fetchComAuth já cuida disso
-      const respostaBackend = await fetchComAuth('/chat', {
+      const respostaBackend = await fetchComAuth('/chat/', {
         method: 'POST',
-        body: JSON.stringify({ prompt: inputMensagem }),
+        body: JSON.stringify({ mensagem: inputMensagem, id_assistant: 'asst_OuBtdCCByhjfqPFPZwMK6d9y' }),
       });
 
       const respostaAI = { remetente: "ai", texto: respostaBackend.resposta };

--- a/frontend-erp/src/modules/MarketingDigitalIA/pages/NovaCampanha.jsx
+++ b/frontend-erp/src/modules/MarketingDigitalIA/pages/NovaCampanha.jsx
@@ -14,7 +14,7 @@ function NovaCampanha() {
   useEffect(() => {
     const carregarPublicosAlvo = async () => {
       try {
-        const dados = await fetchComAuth('/publicos-alvo');
+        const dados = await fetchComAuth('/publicos/');
         setPublicosAlvo(dados);
       } catch (err) {
         setErro('Erro ao carregar públicos-alvo: ' + err.message);
@@ -38,7 +38,7 @@ function NovaCampanha() {
     };
 
     try {
-      const resultado = await fetchComAuth('/nova-campanha', {
+      const resultado = await fetchComAuth('/nova-campanha/', {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json'

--- a/frontend-erp/src/modules/MarketingDigitalIA/pages/NovaPublicacao.jsx
+++ b/frontend-erp/src/modules/MarketingDigitalIA/pages/NovaPublicacao.jsx
@@ -25,7 +25,7 @@ function NovaPublicacao() {
     };
 
     try {
-      const resultado = await fetchComAuth('/nova-publicacao', {
+      const resultado = await fetchComAuth('/nova-publicacao/', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(dados)

--- a/frontend-erp/src/modules/MarketingDigitalIA/pages/PublicosAlvo.jsx
+++ b/frontend-erp/src/modules/MarketingDigitalIA/pages/PublicosAlvo.jsx
@@ -10,7 +10,7 @@ function PublicosAlvo() {
 
   const carregarPublicos = async () => {
     try {
-      const resultado = await fetchComAuth('/publicos');
+      const resultado = await fetchComAuth('/publicos/');
       setPublicos(resultado);
     } catch (err) {
       setErro(err.message);
@@ -23,7 +23,7 @@ function PublicosAlvo() {
 
   const adicionarPublico = async () => {
     try {
-      await fetchComAuth('/publicos', {
+      await fetchComAuth('/publicos/', {
         method: 'POST',
         body: JSON.stringify({ nome, descricao })
       });


### PR DESCRIPTION
## Summary
- fix Chat endpoint path and payload
- fix Nova Campanha path to publicos and endpoint
- ensure Nova Publicacao uses trailing slash
- fix Publicos Alvo endpoints

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `python -m py_compile marketing-digital-ia/backend/**/*.py` *(fails: SyntaxError in files/database.py)*

------
https://chatgpt.com/codex/tasks/task_e_68537cce9264832dbc2a84729c522840