### PR TITLE
Fix production import paths for gateway routing

### DIFF
--- a/frontend-erp/src/modules/Producao/AppProducao.jsx
+++ b/frontend-erp/src/modules/Producao/AppProducao.jsx
@@ -99,7 +99,7 @@ const LoteProducao = () => {
       ...pc,
       operacoes: JSON.parse(localStorage.getItem("op_producao_" + pc.id) || "[]")
     })));
-    const json = await fetchComAuth("/producao/gerar-lote-final", {
+    const json = await fetchComAuth("/gerar-lote-final", {
       method: "POST",
       body: JSON.stringify({ lote: nome, pecas })
     });

--- a/frontend-erp/src/modules/Producao/components/ImportarXML.jsx
+++ b/frontend-erp/src/modules/Producao/components/ImportarXML.jsx
@@ -23,7 +23,7 @@ const ImportarXML = ({ onImportarPacote }) => {
 
     try {
       // URL completa apontando para o gateway, que redirecionará para o backend de produção
-      const data = await fetchComAuth("/producao/importar-xml", {
+      const data = await fetchComAuth("/importar-xml", {
         method: "POST",
         body: formData,
         // Não é mais necessário definir headers aqui, fetchComAuth cuidará disso.


### PR DESCRIPTION
## Summary
- fix ImportarXML to call `/importar-xml`
- fix AppProducao to call `/gerar-lote-final`

## Testing
- `npm install` in `frontend-erp`
- `npm run build` in `frontend-erp`
- `npm run lint` *(fails: Invalid option '--ext')*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_685565d7bedc832dbc0291aeb33364eb