### PR TITLE
Handle ferragens as separate package

### DIFF
--- a/frontend-erp/src/modules/Producao/AppProducao.jsx
+++ b/frontend-erp/src/modules/Producao/AppProducao.jsx
@@ -64,7 +64,7 @@ const LoteProducao = () => {
 
   const salvarPacotes = (novosPacotes) => {
     const pacotesComIds = novosPacotes.map(pacote => {
-      const pecasComIds = pacote.pecas.map(p => {
+      const pecasComIds = (pacote.pecas || []).map(p => {
         const id = globalIdProducao++;
         if (p.operacoes) {
           localStorage.setItem("op_producao_" + id, JSON.stringify(p.operacoes));
@@ -122,7 +122,7 @@ const LoteProducao = () => {
 
       <ul className="space-y-2 mt-4">
         {pacotes.map((p, i) => (
-          <li key={p.id || i} className="border p-2 rounded">
+          <li key={i} className="border p-2 rounded">
             <div className="flex justify-between">
               <div className="font-semibold">{p.nome_pacote || `Pacote ${i + 1}`}</div>
               <div className="space-x-2">

--- a/frontend-erp/src/modules/Producao/components/Pacote.jsx
+++ b/frontend-erp/src/modules/Producao/components/Pacote.jsx
@@ -26,9 +26,9 @@ const Pacote = () => {
     const lotes = JSON.parse(localStorage.getItem("lotesProducao") || "[]");
     const loteAlvo = lotes.find(l => l.nome === nome);
     if (!loteAlvo) return;
-    
+
     const pacoteAlvo = loteAlvo.pacotes[parseInt(indice)];
-    if (!pacoteAlvo) return;
+    if (!pacoteAlvo || !pacoteAlvo.pecas) return;
 
     // Filtra para remover a peça
     pacoteAlvo.pecas = pacoteAlvo.pecas.filter(p => p.id !== id);
@@ -52,7 +52,7 @@ const Pacote = () => {
     setPacote({ ...pacoteAlvo });
   };
 
-  const pecasFiltradas = pacote.pecas.filter(p => {
+  const pecasFiltradas = (pacote.pecas || []).filter(p => {
     const textoBusca = filtroTexto.toLowerCase();
     const valorCampo = p[filtroCampo] ? String(p[filtroCampo]).toLowerCase() : "";
     const codigoPeca = p['codigo_peca'] ? String(p['codigo_peca']).toLowerCase() : "";

--- a/producao/backend/src/operacoes.py
+++ b/producao/backend/src/operacoes.py
@@ -370,9 +370,11 @@ def parse_xml_producao(root, xml_path):
 
     if pecas:
         print(f"📦 Total de peças válidas importadas: {len(pecas)}")
-        pacote = {"nome_pacote": nome_pacote, "pecas": pecas}
-        if ferragens:
-            pacote["ferragens"] = ferragens
-        pacotes.append(pacote)
+        pacotes.append({"nome_pacote": nome_pacote, "pecas": pecas})
+
+    if ferragens:
+        print(f"📦 Total de ferragens importadas: {len(ferragens)}")
+        pacotes.append({"nome_pacote": "Ferragens e Acessórios", "ferragens": ferragens})
+
     print("✅ Finalizado parse_xml_producao")
     return pacotes


### PR DESCRIPTION
## Summary
- return ferragens as dedicated package when parsing XML
- handle packages without pieces when saving/importing
- allow editing packages that only contain ferragens

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `python -m pip install -r requirements.txt`

------
https://chatgpt.com/codex/tasks/task_e_68557b7865fc832daf323fc3ca7ef176