### PR TITLE
fix classification of ferragens

### DIFF
--- a/producao/backend/src/operacoes.py
+++ b/producao/backend/src/operacoes.py
@@ -137,13 +137,14 @@ def classificar_item(item):
     largura = float(item.get("WIDTH", 0))
     comprimento = float(item.get("DEPTH", 0))
     espessura = float(item.get("HEIGHT", 0))
-    if item.get("COMPONENT") != "Y" or item.get("STRUCTURE") != "N":
-        return "outro"
-
     # Considerar famílias de ferragens e acessórios como ferragem para que os
-    # itens sejam corretamente importados
+    # itens sejam corretamente importados, independentemente dos campos
+    # COMPONENT ou STRUCTURE
     if family in ["acessórios", "ferragem", "ferragens"]:
         return "ferragem"
+
+    if item.get("COMPONENT") != "Y" or item.get("STRUCTURE") != "N":
+        return "outro"
 
     if family == "roteiro produtivo":
         return "outro"


### PR DESCRIPTION
## Summary
- detect ferragens using family name even when COMPONENT/STRUCTURE flags do not match

## Testing
- `python -m py_compile producao/backend/src/operacoes.py`
- `find . -name '*.py' -print | xargs python -m py_compile` *(fails: SyntaxError in marketing-digital-ia/backend/files/main.py)*

------
https://chatgpt.com/codex/tasks/task_e_68558f44f8a8832d979cd0c633bd72c1