### PR TITLE
Fix Ferragens subpackage position

### DIFF
--- a/producao/backend/src/operacoes.py
+++ b/producao/backend/src/operacoes.py
@@ -397,10 +397,16 @@ def parse_xml_orcamento(root):
             else:
                 ferragens.append({"nome": nome_ferragem, "quantidade": quantidade})
 
+    # Combina MDF e ferragens em um único pacote para que o frontend exiba as
+    # ferragens como um "subpacote" dentro da tela do pacote principal.
+    pacote = {"nome_pacote": nome_pacote}
     if pecas:
-        pacotes.append({"nome_pacote": nome_pacote, "pecas": pecas})
+        pacote["pecas"] = pecas
     if ferragens:
-        pacotes.append({"nome_pacote": "Ferragens e Acessórios", "ferragens": ferragens})
+        pacote["ferragens"] = ferragens
+
+    if pacote.get("pecas") or pacote.get("ferragens"):
+        pacotes.append(pacote)
 
     return pacotes
 
@@ -513,10 +519,17 @@ def parse_xml_producao(root, xml_path):
         print(
             f"✅ Itens classificados: {len(pecas)} peças de MDF, {len(ferragens)} tipos de ferragens."
         )
+
+    # Assim como em parse_xml_orcamento, as ferragens são incorporadas ao mesmo
+    # pacote de MDF para facilitar a exibição no frontend.
+    pacote = {"nome_pacote": nome_pacote}
     if pecas:
-        pacotes.append({"nome_pacote": nome_pacote, "pecas": pecas})
+        pacote["pecas"] = pecas
     if ferragens:
-        pacotes.append({"nome_pacote": "Ferragens e Acessórios", "ferragens": ferragens})
+        pacote["ferragens"] = ferragens
+
+    if pacote.get("pecas") or pacote.get("ferragens"):
+        pacotes.append(pacote)
 
     print("✅ Finalizado parse_xml_producao")
     return pacotes


### PR DESCRIPTION
## Summary
- keep ferragens items inside the main package returned by the backend

## Testing
- `python -m py_compile producao/backend/src/operacoes.py`
- `python -m py_compile producao/backend/src/api.py`
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6855a36e193c832d83133e435e3432ac