### PR TITLE
Fix ferragem description display

### DIFF
--- a/frontend-erp/src/modules/Producao/components/EditarFerragem.jsx
+++ b/frontend-erp/src/modules/Producao/components/EditarFerragem.jsx
@@ -33,7 +33,10 @@ const EditarFerragem = () => {
       const idx = (pacote.ferragens || []).findIndex(x => x.id === parseInt(id));
       if (idx >= 0) {
         pacote.ferragens[idx].quantidade = quantidade;
-        if (substituir) pacote.ferragens[idx].descricao = substituir;
+        if (substituir) {
+          pacote.ferragens[idx].descricao = substituir;
+          pacote.ferragens[idx].nome = substituir;
+        }
       }
     }
     localStorage.setItem("lotesProducao", JSON.stringify(lotes));
@@ -45,7 +48,7 @@ const EditarFerragem = () => {
   return (
     <div className="p-6 space-y-4">
       <h3 className="text-lg font-semibold">Editar Ferragem</h3>
-      <p>ID {String(ferragem.id).padStart(6,'0')} - {ferragem.descricao}</p>
+      <p>ID {String(ferragem.id).padStart(6,'0')} - {ferragem.descricao || ferragem.nome}</p>
       <label className="block">Quantidade:
         <input type="number" className="input" value={quantidade} onChange={e => setQuantidade(parseInt(e.target.value))} />
       </label>

--- a/frontend-erp/src/modules/Producao/components/Pacote.jsx
+++ b/frontend-erp/src/modules/Producao/components/Pacote.jsx
@@ -104,7 +104,7 @@ const Pacote = () => {
           <ul className="space-y-2">
             {pacote.ferragens.map(f => (
               <li key={f.id} className="border rounded p-3 flex justify-between">
-                <span><strong>ID {String(f.id).padStart(6,'0')}</strong>: {f.descricao} - {f.quantidade}</span>
+                <span><strong>ID {String(f.id).padStart(6,'0')}</strong>: {f.descricao || f.nome} - {f.quantidade}</span>
                 <div className="space-x-2">
                   <Button onClick={() => navigate(`/producao/lote/${nome}/ferragem/${f.id}`)}>Editar</Button>
                   <Button variant="destructive" onClick={() => excluirFerragem(f.id)}>Excluir</Button>


### PR DESCRIPTION
## Summary
- show ferragem name when description is missing
- preserve description and name when substituting ferragem

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6855a68c597c832dbed20cdaec222bfe