### PR TITLE
Fix volume screen shows only closed volumes

### DIFF
--- a/frontend-erp/src/modules/Producao/components/Apontamento.jsx
+++ b/frontend-erp/src/modules/Producao/components/Apontamento.jsx
@@ -40,7 +40,7 @@ const Apontamento = () => {
   };
 
   const gerarCodigoBarra = (num) => {
-    return `VOL-${Date.now()}-${num}`;
+    return `${Date.now()}${num}`;
   };
 
   const imprimirEtiqueta = (volume) => {

--- a/frontend-erp/src/modules/Producao/components/ApontamentoVolume.jsx
+++ b/frontend-erp/src/modules/Producao/components/ApontamentoVolume.jsx
@@ -2,19 +2,15 @@ import React, { useState, useEffect } from "react";
 import JsBarcode from "jsbarcode";
 import FiltroPacote from "./FiltroPacote";
 
-const CODE_FECHA_VOLUME = "999999";
-
 const ApontamentoVolume = () => {
   const [lote, setLote] = useState("");
   const [pacoteIndex, setPacoteIndex] = useState("");
-  const [codigo, setCodigo] = useState("");
-  const [apontados, setApontados] = useState([]);
   const [volumes, setVolumes] = useState([]);
+  const [codigo, setCodigo] = useState("");
 
   const lotes = JSON.parse(localStorage.getItem("lotesProducao") || "[]");
   const pacotes = lote ? (lotes.find(l => l.nome === lote)?.pacotes || []) : [];
   const pacote = pacotes[parseInt(pacoteIndex)] || null;
-  const itensPacote = pacote ? [...(pacote.pecas || []), ...(pacote.ferragens || [])] : [];
 
   useEffect(() => {
     if (pacote) {
@@ -22,25 +18,21 @@ const ApontamentoVolume = () => {
     } else {
       setVolumes([]);
     }
-    setApontados([]);
     setCodigo("");
   }, [pacoteIndex, lote]);
 
-  const salvarVolumes = (novos) => {
-    const atual = JSON.parse(localStorage.getItem("lotesProducao") || "[]");
-    const idxLote = atual.findIndex(l => l.nome === lote);
-    if (idxLote >= 0) {
-      if (!atual[idxLote].pacotes[parseInt(pacoteIndex)].volumes) {
-        atual[idxLote].pacotes[parseInt(pacoteIndex)].volumes = [];
-      }
-      atual[idxLote].pacotes[parseInt(pacoteIndex)].volumes = novos;
-      localStorage.setItem("lotesProducao", JSON.stringify(atual));
+  const registrarCodigo = (e) => {
+    e.preventDefault();
+    const cod = codigo.trim();
+    if (!cod) return;
+    const vol = volumes.find(v => v.barcode === cod);
+    if (vol) {
+      imprimirEtiqueta(vol);
+    } else {
+      alert("Volume não encontrado");
     }
+    setCodigo("");
   };
-
-const gerarCodigoBarra = (num) => {
-  return `VOL-${Date.now()}-${num}`;
-};
 
   const imprimirEtiqueta = (volume) => {
     const printWindow = window.open('', '_blank', 'width=400,height=400');
@@ -65,37 +57,6 @@ const gerarCodigoBarra = (num) => {
     printWindow.close();
   };
 
-  const registrarCodigo = (e) => {
-    e.preventDefault();
-    if (!pacote) return;
-    const cod = codigo.trim();
-    if (!cod) return;
-    if (cod === CODE_FECHA_VOLUME) {
-      if (apontados.length) {
-        const itensVolume = apontados.map(id => itensPacote.find(p => p.id === id));
-        const novoVolume = {
-          numero: volumes.length + 1,
-          pecas: itensVolume,
-          barcode: gerarCodigoBarra(volumes.length + 1)
-        };
-        const atualizados = [...volumes, novoVolume];
-        setVolumes(atualizados);
-        salvarVolumes(atualizados);
-        setApontados([]);
-        imprimirEtiqueta(novoVolume);
-      }
-    } else {
-      const item = itensPacote.find(p => String(p.id).padStart(6,'0') === cod);
-      if (item) {
-        if (!apontados.includes(item.id)) {
-          setApontados([...apontados, item.id]);
-        }
-      } else {
-        alert("Código não encontrado no pacote");
-      }
-    }
-    setCodigo("");
-  };
 
   return (
     <div className="p-6">
@@ -113,33 +74,29 @@ const gerarCodigoBarra = (num) => {
           <form onSubmit={registrarCodigo} className="mb-4">
             <input
               className="input w-full sm:w-64"
-              placeholder="ID do item ou 999999 para fechar volume"
+              placeholder="Código de barras do volume"
               value={codigo}
               onChange={e => setCodigo(e.target.value)}
               autoFocus
             />
           </form>
-          <ul className="space-y-1 max-h-64 overflow-y-auto mb-4">
-            {itensPacote.map(item => (
-              <li
-                key={item.id}
-                className={`border rounded p-2 ${apontados.includes(item.id) ? 'bg-green-200' : ''}`}
-              >
-                <span className="font-mono mr-2">{String(item.id).padStart(6,'0')}</span>
-                {item.nome || item.descricao}
-              </li>
-            ))}
-          </ul>
-          <h3 className="font-semibold mb-2">Volumes Criados</h3>
           <ul className="space-y-2">
             {volumes.map(v => (
               <li key={v.numero} className="border rounded p-2">
-                <div className="font-semibold">Volume {v.numero} - {v.barcode}</div>
-                <ul className="text-sm list-disc ml-4">
-                  {v.pecas.map(pc => (
-                    <li key={pc.id}>{String(pc.id).padStart(6,'0')} - {pc.nome || pc.descricao}</li>
-                  ))}
-                </ul>
+                <div className="font-semibold flex justify-between items-center">
+                <span>Volume {v.numero} - {v.barcode}</span>
+                <button
+                  onClick={() => imprimirEtiqueta(v)}
+                  className="text-sm text-blue-600 underline"
+                >
+                  Imprimir
+                </button>
+              </div>
+              <ul className="text-sm list-disc ml-4">
+                {v.pecas.map(pc => (
+                  <li key={pc.id}>{String(pc.id).padStart(6,'0')} - {pc.nome || pc.descricao}</li>
+                ))}
+              </ul>
               </li>
             ))}
           </ul>


### PR DESCRIPTION
## Summary
- simplify `ApontamentoVolume.jsx` to display just closed volumes
- allow reprinting labels for each volume
- add barcode scanning field for quick reprint
- generate numeric-only barcodes for new volumes

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6855be052168832d869b53aa2f9573b5