### PR TITLE
Implement nesting screen and backend improvements

### DIFF
--- a/frontend-erp/src/modules/Producao/AppProducao.jsx
+++ b/frontend-erp/src/modules/Producao/AppProducao.jsx
@@ -8,6 +8,7 @@ import Pacote from "./components/Pacote";
 import Apontamento from "./components/Apontamento";
 import ApontamentoVolume from "./components/ApontamentoVolume";
 import EditarFerragem from "./components/EditarFerragem";
+import Nesting from "./components/Nesting";
 import "./Producao.css";
 
 let globalIdProducao = parseInt(localStorage.getItem("globalPecaIdProducao")) || 1;
@@ -394,4 +395,4 @@ const EditarPecaProducao = () => {
 };
 
 // Reexporta os componentes para uso no index.jsx do módulo
-export { HomeProducao, LoteProducao, EditarPecaProducao, Pacote, Apontamento, ApontamentoVolume, EditarFerragem, ImportarXML, VisualizacaoPeca };
+export { HomeProducao, LoteProducao, EditarPecaProducao, Pacote, Apontamento, ApontamentoVolume, EditarFerragem, ImportarXML, VisualizacaoPeca, Nesting };

--- a/frontend-erp/src/modules/Producao/components/Nesting.jsx
+++ b/frontend-erp/src/modules/Producao/components/Nesting.jsx
@@ -1,0 +1,88 @@
+import React, { useState, useEffect } from "react";
+import { fetchComAuth } from "../../../utils/fetchComAuth";
+import { Button } from "./ui/button";
+
+const Nesting = () => {
+  const [pastaLote, setPastaLote] = useState("");
+  const [larguraChapa, setLarguraChapa] = useState(2750);
+  const [alturaChapa, setAlturaChapa] = useState(1850);
+  const [resultado, setResultado] = useState("");
+
+  useEffect(() => {
+    const cfg = JSON.parse(localStorage.getItem("nestingConfig") || "{}");
+    if (cfg.pastaLote) setPastaLote(cfg.pastaLote);
+    if (cfg.larguraChapa) setLarguraChapa(cfg.larguraChapa);
+    if (cfg.alturaChapa) setAlturaChapa(cfg.alturaChapa);
+  }, []);
+
+  const salvar = () => {
+    localStorage.setItem(
+      "nestingConfig",
+      JSON.stringify({ pastaLote, larguraChapa, alturaChapa })
+    );
+    alert("Configurações salvas");
+  };
+
+  const executar = async () => {
+    try {
+      const data = await fetchComAuth("/executar-nesting", {
+        method: "POST",
+        body: JSON.stringify({
+          pasta_lote: pastaLote,
+          largura_chapa: parseFloat(larguraChapa),
+          altura_chapa: parseFloat(alturaChapa),
+        }),
+      });
+      if (data?.erro) {
+        alert(data.erro);
+      } else if (data?.pasta_resultado) {
+        setResultado(data.pasta_resultado);
+      }
+    } catch (err) {
+      alert("Falha ao executar nesting");
+      console.error(err);
+    }
+  };
+
+  return (
+    <div className="p-6 space-y-4">
+      <h2 className="text-lg font-semibold">Configuração de Nesting</h2>
+      <label className="block">
+        <span className="text-sm">Pasta do Lote</span>
+        <input
+          type="text"
+          className="input w-full"
+          value={pastaLote}
+          onChange={(e) => setPastaLote(e.target.value)}
+        />
+      </label>
+      <label className="block">
+        <span className="text-sm">Largura da chapa (mm)</span>
+        <input
+          type="number"
+          className="input w-full"
+          value={larguraChapa}
+          onChange={(e) => setLarguraChapa(e.target.value)}
+        />
+      </label>
+      <label className="block">
+        <span className="text-sm">Altura da chapa (mm)</span>
+        <input
+          type="number"
+          className="input w-full"
+          value={alturaChapa}
+          onChange={(e) => setAlturaChapa(e.target.value)}
+        />
+      </label>
+      <div className="space-x-2">
+        <Button onClick={salvar}>Salvar</Button>
+        <Button onClick={executar}>Executar Nesting</Button>
+      </div>
+      {resultado && (
+        <p className="text-sm">Arquivos gerados em: {resultado}</p>
+      )}
+    </div>
+  );
+};
+
+export default Nesting;

--- a/frontend-erp/src/modules/Producao/index.jsx
+++ b/frontend-erp/src/modules/Producao/index.jsx
@@ -2,7 +2,7 @@
 import React from 'react';
 import { Routes, Route, Link, Outlet, useResolvedPath, useMatch } from 'react-router-dom';
 // Importa os componentes renomeados do AppProducao.jsx
-import { HomeProducao, LoteProducao, EditarPecaProducao, Pacote, Apontamento, ApontamentoVolume, EditarFerragem } from './AppProducao';
+import { HomeProducao, LoteProducao, EditarPecaProducao, Pacote, Apontamento, ApontamentoVolume, EditarFerragem, Nesting } from './AppProducao';
 
 function ProducaoLayout() {
   const resolved = useResolvedPath(''); // O caminho base para este módulo
@@ -11,6 +11,7 @@ function ProducaoLayout() {
   const matchLote = useMatch(`${resolved.pathname}/lote/*`); // Matches /producao/lote/qualquer_nome
   const matchApontamento = useMatch({ path: `${resolved.pathname}/apontamento`, end: true });
   const matchVolume = useMatch({ path: `${resolved.pathname}/apontamento-volume`, end: true });
+  const matchNesting = useMatch({ path: `${resolved.pathname}/nesting`, end: true });
 
   return (
     <div className="p-4 bg-white rounded shadow-md">
@@ -34,6 +35,12 @@ function ProducaoLayout() {
         >
           Apontamento Volume
         </Link>
+        <Link
+          to="nesting"
+          className={`px-3 py-1 rounded ${matchNesting ? 'bg-blue-200 text-blue-800' : 'text-blue-600 hover:bg-blue-100'}`}
+        >
+          Nesting
+        </Link>
         {/* Adicionar mais links de navegação interna do módulo, se necessário */}
       </nav>
       <Outlet /> {/* Renderiza as rotas aninhadas aqui */}
@@ -52,6 +59,7 @@ function Producao() {
         <Route path="lote/:nome/ferragem/:id" element={<EditarFerragem />} />
         <Route path="apontamento" element={<Apontamento />} />
         <Route path="apontamento-volume" element={<ApontamentoVolume />} />
+        <Route path="nesting" element={<Nesting />} />
       </Route>
     </Routes>
   );

--- a/frontend-erp/src/utils/fetchComAuth.js
+++ b/frontend-erp/src/utils/fetchComAuth.js
@@ -21,7 +21,7 @@ export async function fetchComAuth(url, options = {}) {
   if (url.startsWith('/')) { // Se for uma rota relativa
       if (url.startsWith('/publicos') || url.startsWith('/nova-campanha') || url.startsWith('/nova-publicacao') || url.startsWith('/chat') || url.startsWith('/conhecimento')) {
           finalUrl = `${GATEWAY_URL}/marketing-ia${url}`; // Rotas do Marketing Digital IA via Gateway
-      } else if (url.startsWith('/importar-xml') || url.startsWith('/gerar-lote-final')) {
+      } else if (url.startsWith('/importar-xml') || url.startsWith('/gerar-lote-final') || url.startsWith('/executar-nesting')) {
           finalUrl = `${GATEWAY_URL}/producao${url}`; // Rotas de Produção via Gateway
       } else if (url.startsWith('/auth')) {
           finalUrl = `${GATEWAY_URL}${url}`; // Endpoints de autenticação direto no Gateway

--- a/producao/backend/src/api.py
+++ b/producao/backend/src/api.py
@@ -107,10 +107,12 @@ async def gerar_lote_final(request: Request):
 async def executar_nesting(request: Request):
     dados = await request.json()
     pasta_lote = dados.get('pasta_lote')
+    largura_chapa = float(dados.get('largura_chapa', 2750))
+    altura_chapa = float(dados.get('altura_chapa', 1850))
     if not pasta_lote:
         return {"erro": "Parâmetro 'pasta_lote' não informado."}
     try:
-        pasta_resultado = gerar_nesting(pasta_lote)
+        pasta_resultado = gerar_nesting(pasta_lote, largura_chapa, altura_chapa)
     except Exception as e:
         return {"erro": str(e)}
     return {"status": "ok", "pasta_resultado": pasta_resultado}

--- a/producao/backend/src/requirements.txt
+++ b/producao/backend/src/requirements.txt
@@ -1,3 +1,4 @@
 fastapi
 uvicorn
 ezdxf
+rectpack


### PR DESCRIPTION
## Summary
- add a simple `Nesting` screen in Produção module
- route `/nesting` in frontend
- update URL utility to allow `/executar-nesting`
- implement rectpack‑based nesting backend with label and gcode generation
- allow passing sheet size parameters
- update requirements with rectpack

## Testing
- `python -m py_compile producao/backend/src/*.py`
- `npm run lint` *(fails: Invalid option '--ext')*

------
https://chatgpt.com/codex/tasks/task_e_6855eb04018c832d8a2c6967b8ae41aa