### PR TITLE
Implement folder list for Nesting module

### DIFF
--- a/frontend-erp/src/modules/Producao/components/Nesting.jsx
+++ b/frontend-erp/src/modules/Producao/components/Nesting.jsx
@@ -4,6 +4,7 @@ import { Button } from "./ui/button";
 
 const Nesting = () => {
   const [pastaLote, setPastaLote] = useState("");
+  const [lotes, setLotes] = useState([]);
   const [larguraChapa, setLarguraChapa] = useState(2750);
   const [alturaChapa, setAlturaChapa] = useState(1850);
   const [resultado, setResultado] = useState("");
@@ -13,6 +14,9 @@ const Nesting = () => {
     if (cfg.pastaLote) setPastaLote(cfg.pastaLote);
     if (cfg.larguraChapa) setLarguraChapa(cfg.larguraChapa);
     if (cfg.alturaChapa) setAlturaChapa(cfg.alturaChapa);
+    fetchComAuth("/listar-lotes")
+      .then((d) => setLotes(d?.lotes || []))
+      .catch((e) => console.error("Falha ao carregar lotes", e));
   }, []);
 
   const salvar = () => {
@@ -49,12 +53,18 @@ const Nesting = () => {
       <h2 className="text-lg font-semibold">Configuração de Nesting</h2>
       <label className="block">
         <span className="text-sm">Pasta do Lote</span>
-        <input
-          type="text"
+        <select
           className="input w-full"
           value={pastaLote}
           onChange={(e) => setPastaLote(e.target.value)}
-        />
+        >
+          <option value="">Selecione...</option>
+          {lotes.map((l) => (
+            <option key={l} value={l}>
+              {l}
+            </option>
+          ))}
+        </select>
       </label>
       <label className="block">
         <span className="text-sm">Largura da chapa (mm)</span>

--- a/frontend-erp/src/utils/fetchComAuth.js
+++ b/frontend-erp/src/utils/fetchComAuth.js
@@ -21,7 +21,7 @@ export async function fetchComAuth(url, options = {}) {
   if (url.startsWith('/')) { // Se for uma rota relativa
       if (url.startsWith('/publicos') || url.startsWith('/nova-campanha') || url.startsWith('/nova-publicacao') || url.startsWith('/chat') || url.startsWith('/conhecimento')) {
           finalUrl = `${GATEWAY_URL}/marketing-ia${url}`; // Rotas do Marketing Digital IA via Gateway
-      } else if (url.startsWith('/importar-xml') || url.startsWith('/gerar-lote-final') || url.startsWith('/executar-nesting')) {
+      } else if (url.startsWith('/importar-xml') || url.startsWith('/gerar-lote-final') || url.startsWith('/executar-nesting') || url.startsWith('/listar-lotes')) {
           finalUrl = `${GATEWAY_URL}/producao${url}`; // Rotas de Produção via Gateway
       } else if (url.startsWith('/auth')) {
           finalUrl = `${GATEWAY_URL}${url}`; // Endpoints de autenticação direto no Gateway

--- a/producao/backend/src/api.py
+++ b/producao/backend/src/api.py
@@ -116,3 +116,13 @@ async def executar_nesting(request: Request):
     except Exception as e:
         return {"erro": str(e)}
     return {"status": "ok", "pasta_resultado": pasta_resultado}
+
+
+@app.get("/listar-lotes")
+async def listar_lotes():
+    """Retorna uma lista das pastas de lote disponíveis em 'saida'."""
+    base = Path("saida")
+    if not base.is_dir():
+        return {"lotes": []}
+    lotes = [str(p) for p in sorted(base.iterdir(), key=lambda x: x.name) if p.is_dir() and p.name.startswith("Lote_")]
+    return {"lotes": lotes}


### PR DESCRIPTION
## Summary
- add `/listar-lotes` endpoint in production API
- route new endpoint through gateway helper
- populate Nesting config with available lot folders
- show dropdown of lot folders instead of text input

## Testing
- `npm run lint`
- `python -m py_compile api.py`


------
https://chatgpt.com/codex/tasks/task_e_6856b8edca74832dae71b1fb3c936a42