### PR TITLE
Fix env var usage in frontend

### DIFF
--- a/frontend-erp/.env.example
+++ b/frontend-erp/.env.example
@@ -1,1 +1,5 @@
 VITE_GATEWAY_URL=http://localhost:8010
+
+# Optional default credentials for automatic login during development
+VITE_DEFAULT_USERNAME=
+VITE_DEFAULT_PASSWORD=

--- a/frontend-erp/src/App.jsx
+++ b/frontend-erp/src/App.jsx
@@ -64,8 +64,8 @@ function App() {
         }
       }
 
-        const defaultUser = process.env.REACT_APP_DEFAULT_USERNAME;
-        const defaultPass = process.env.REACT_APP_DEFAULT_PASSWORD;
+        const defaultUser = import.meta.env.VITE_DEFAULT_USERNAME;
+        const defaultPass = import.meta.env.VITE_DEFAULT_PASSWORD;
 
         if (defaultUser && defaultPass) {
           try {


### PR DESCRIPTION
## Summary
- fix env var access in `App.jsx`
- document default login env vars in `.env.example`

## Testing
- `npm run lint` *(fails: Invalid option '--ext')*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68593af249b4832d8f83e12192d0e1e9