### PR TITLE
Add machine config management for Nesting

### DIFF
--- a/frontend-erp/src/modules/Producao/AppProducao.jsx
+++ b/frontend-erp/src/modules/Producao/AppProducao.jsx
@@ -9,6 +9,7 @@ import Apontamento from "./components/Apontamento";
 import ApontamentoVolume from "./components/ApontamentoVolume";
 import EditarFerragem from "./components/EditarFerragem";
 import Nesting from "./components/Nesting";
+import ConfigMaquina from "./components/ConfigMaquina";
 import "./Producao.css";
 
 let globalIdProducao = parseInt(localStorage.getItem("globalPecaIdProducao")) || 1;
@@ -395,4 +396,4 @@ const EditarPecaProducao = () => {
 };
 
 // Reexporta os componentes para uso no index.jsx do módulo
-export { HomeProducao, LoteProducao, EditarPecaProducao, Pacote, Apontamento, ApontamentoVolume, EditarFerragem, ImportarXML, VisualizacaoPeca, Nesting };
+export { HomeProducao, LoteProducao, EditarPecaProducao, Pacote, Apontamento, ApontamentoVolume, EditarFerragem, ImportarXML, VisualizacaoPeca, Nesting, ConfigMaquina };

--- a/frontend-erp/src/modules/Producao/components/ConfigMaquina.jsx
+++ b/frontend-erp/src/modules/Producao/components/ConfigMaquina.jsx
@@ -1,0 +1,220 @@
+import React, { useState, useEffect } from "react";
+import { Button } from "./ui/button";
+
+const modeloFerramenta = {
+  tipo: "Fresa",
+  sentidoCorte: "Horário",
+  codigo: "",
+  tipoFerramenta: "Fresa de topo raso",
+  descricao: "",
+  diametro: "",
+  areaCorteLimite: "",
+  comprimentoUtil: "",
+  entradaChapa: "",
+  velocidadeRotacao: "",
+  velocidadeCorte: "",
+  velocidadeEntrada: "",
+  velocidadeReduzida: "",
+  anguloEntrada: "",
+  comandoExtra: "",
+};
+
+const ConfigMaquina = () => {
+  const [ferramentas, setFerramentas] = useState([]);
+  const [mostrarForm, setMostrarForm] = useState(false);
+  const [editIndex, setEditIndex] = useState(null);
+  const [form, setForm] = useState(modeloFerramenta);
+
+  useEffect(() => {
+    const salvas = JSON.parse(localStorage.getItem("ferramentasNesting") || "[]");
+    setFerramentas(salvas);
+  }, []);
+
+  const salvarLS = (dados) => {
+    setFerramentas(dados);
+    localStorage.setItem("ferramentasNesting", JSON.stringify(dados));
+  };
+
+  const novo = () => {
+    setForm(modeloFerramenta);
+    setEditIndex(null);
+    setMostrarForm(true);
+  };
+
+  const editar = (idx) => {
+    setForm({ ...ferramentas[idx] });
+    setEditIndex(idx);
+    setMostrarForm(true);
+  };
+
+  const remover = (idx) => {
+    const nov = ferramentas.filter((_, i) => i !== idx);
+    salvarLS(nov);
+  };
+
+  const salvar = () => {
+    const lista = [...ferramentas];
+    if (editIndex !== null) lista[editIndex] = form; else lista.push(form);
+    salvarLS(lista);
+    setMostrarForm(false);
+  };
+
+  const handle = (campo) => (e) => setForm({ ...form, [campo]: e.target.value });
+
+  const Item = ({f, i}) => (
+    <li className="flex justify-between border rounded p-2" key={i}>
+      <div>
+        <div className="text-sm font-medium">{f.codigo}</div>
+        <div className="text-xs">{f.diametro}mm - {f.descricao}</div>
+      </div>
+      <div className="space-x-1">
+        <Button size="sm" variant="outline" onClick={() => editar(i)}>Editar</Button>
+        <Button size="sm" variant="destructive" onClick={() => remover(i)}>Excluir</Button>
+      </div>
+    </li>
+  );
+
+  return (
+    <div className="p-6 space-y-4">
+      <h2 className="text-lg font-semibold">Ferramentas</h2>
+      <Button onClick={novo}>Cadastrar Nova Ferramenta</Button>
+      {mostrarForm && (
+        <div className="border p-4 rounded space-y-2">
+          <label className="block">
+            <span className="text-sm">Tipo</span>
+            <select className="input" value={form.tipo} onChange={handle('tipo')}>
+              <option>Fresa</option>
+              <option>Broca</option>
+            </select>
+          </label>
+          {form.tipo === 'Fresa' && (
+            <>
+              <label className="block">
+                <span className="text-sm">Sentido do corte</span>
+                <select className="input" value={form.sentidoCorte} onChange={handle('sentidoCorte')}>
+                  <option>Horário</option>
+                  <option>Anti-horário</option>
+                </select>
+              </label>
+              <label className="block">
+                <span className="text-sm">Código da ferramenta na máquina</span>
+                <input className="input" value={form.codigo} onChange={handle('codigo')} />
+              </label>
+              <label className="block">
+                <span className="text-sm">Tipo de ferramenta</span>
+                <select className="input" value={form.tipoFerramenta} onChange={handle('tipoFerramenta')}>
+                  <option>Fresa de topo raso</option>
+                  <option>Fresa V-Bit</option>
+                </select>
+              </label>
+              <label className="block">
+                <span className="text-sm">Descrição da Ferramenta</span>
+                <input className="input" value={form.descricao} onChange={handle('descricao')} />
+              </label>
+              <label className="block">
+                <span className="text-sm">Diâmetro da Ferramenta em (mm)</span>
+                <input type="number" className="input" value={form.diametro} onChange={handle('diametro')} />
+              </label>
+              <label className="block">
+                <span className="text-sm">Área de Corte Limite em (mm)</span>
+                <input type="number" className="input" value={form.areaCorteLimite} onChange={handle('areaCorteLimite')} />
+              </label>
+              <label className="block">
+                <span className="text-sm">Comprimento Ú til da Ferramenta em (mm)</span>
+                <input type="number" className="input" value={form.comprimentoUtil} onChange={handle('comprimentoUtil')} />
+              </label>
+              <label className="block">
+                <span className="text-sm">Entrada na Chapa de Sacrifício (mm)</span>
+                <input type="number" className="input" value={form.entradaChapa} onChange={handle('entradaChapa')} />
+              </label>
+              <label className="block">
+                <span className="text-sm">Velocidade de Rotação do Spindle (RPM)</span>
+                <input type="number" className="input" value={form.velocidadeRotacao} onChange={handle('velocidadeRotacao')} />
+              </label>
+              <label className="block">
+                <span className="text-sm">Velocidade de Corte da Ferramenta (mm/min)</span>
+                <input type="number" className="input" value={form.velocidadeCorte} onChange={handle('velocidadeCorte')} />
+              </label>
+              <label className="block">
+                <span className="text-sm">Velocidade de Entrada da Ferramenta no Material (mm/min)</span>
+                <input type="number" className="input" value={form.velocidadeEntrada} onChange={handle('velocidadeEntrada')} />
+              </label>
+              <label className="block">
+                <span className="text-sm">Velocidade de Corte Reduzida (mm/min)</span>
+                <input type="number" className="input" value={form.velocidadeReduzida} onChange={handle('velocidadeReduzida')} />
+              </label>
+              <label className="block">
+                <span className="text-sm">Â ngulo de Entrada da Ferramenta (°graus)</span>
+                <input type="number" className="input" value={form.anguloEntrada} onChange={handle('anguloEntrada')} />
+              </label>
+              <label className="block">
+                <span className="text-sm">Comando Extra</span>
+                <input className="input" value={form.comandoExtra} onChange={handle('comandoExtra')} />
+              </label>
+            </>
+          )}
+          {form.tipo === 'Broca' && (
+            <>
+              <label className="block">
+                <span className="text-sm">Código da ferramenta na máquina</span>
+                <input className="input" value={form.codigo} onChange={handle('codigo')} />
+              </label>
+              <label className="block">
+                <span className="text-sm">Descrição da Ferramenta</span>
+                <input className="input" value={form.descricao} onChange={handle('descricao')} />
+              </label>
+              <label className="block">
+                <span className="text-sm">Diâmetro da Ferramenta em (mm)</span>
+                <input type="number" className="input" value={form.diametro} onChange={handle('diametro')} />
+              </label>
+              <label className="block">
+                <span className="text-sm">Área de Corte Limite em (mm)</span>
+                <input type="number" className="input" value={form.areaCorteLimite} onChange={handle('areaCorteLimite')} />
+              </label>
+              <label className="block">
+                <span className="text-sm">Comprimento Ú til da Ferramenta em (mm)</span>
+                <input type="number" className="input" value={form.comprimentoUtil} onChange={handle('comprimentoUtil')} />
+              </label>
+              <label className="block">
+                <span className="text-sm">Entrada na Chapa de Sacrifício (mm)</span>
+                <input type="number" className="input" value={form.entradaChapa} onChange={handle('entradaChapa')} />
+              </label>
+              <label className="block">
+                <span className="text-sm">Velocidade de Rotação do Spindle (RPM)</span>
+                <input type="number" className="input" value={form.velocidadeRotacao} onChange={handle('velocidadeRotacao')} />
+              </label>
+              <label className="block">
+                <span className="text-sm">Velocidade de Corte da Ferramenta (mm/min)</span>
+                <input type="number" className="input" value={form.velocidadeCorte} onChange={handle('velocidadeCorte')} />
+              </label>
+              <label className="block">
+                <span className="text-sm">Comando Extra</span>
+                <input className="input" value={form.comandoExtra} onChange={handle('comandoExtra')} />
+              </label>
+            </>
+          )}
+          <div className="space-x-2 pt-2">
+            <Button onClick={salvar}>Salvar</Button>
+            <Button variant="outline" onClick={() => setMostrarForm(false)}>Cancelar</Button>
+          </div>
+        </div>
+      )}
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+        <div>
+          <h3 className="font-semibold">Fresas</h3>
+          <ul className="space-y-1">
+            {ferramentas.filter(f => f.tipo === 'Fresa').map((f, i) => <Item f={f} i={i} key={i} />)}
+          </ul>
+        </div>
+        <div>
+          <h3 className="font-semibold">Brocas</h3>
+          <ul className="space-y-1">
+            {ferramentas.filter(f => f.tipo === 'Broca').map((f, i) => <Item f={f} i={i} key={i} />)}
+          </ul>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default ConfigMaquina;

--- a/frontend-erp/src/modules/Producao/components/Nesting.jsx
+++ b/frontend-erp/src/modules/Producao/components/Nesting.jsx
@@ -1,8 +1,10 @@
 import React, { useState, useEffect } from "react";
+import { useNavigate } from "react-router-dom";
 import { fetchComAuth } from "../../../utils/fetchComAuth";
 import { Button } from "./ui/button";
 
 const Nesting = () => {
+  const navigate = useNavigate();
   const [pastaLote, setPastaLote] = useState("");
   const [lotes, setLotes] = useState([]);
   const [larguraChapa, setLarguraChapa] = useState(2750);
@@ -29,12 +31,14 @@ const Nesting = () => {
 
   const executar = async () => {
     try {
+      const ferramentas = JSON.parse(localStorage.getItem("ferramentasNesting") || "[]");
       const data = await fetchComAuth("/executar-nesting", {
         method: "POST",
         body: JSON.stringify({
           pasta_lote: pastaLote,
           largura_chapa: parseFloat(larguraChapa),
           altura_chapa: parseFloat(alturaChapa),
+          ferramentas,
         }),
       });
       if (data?.erro) {
@@ -85,6 +89,7 @@ const Nesting = () => {
         />
       </label>
       <div className="space-x-2">
+        <Button variant="outline" onClick={() => navigate('config-maquina')}>Configurar Máquina</Button>
         <Button onClick={salvar}>Salvar</Button>
         <Button onClick={executar}>Executar Nesting</Button>
       </div>

--- a/frontend-erp/src/modules/Producao/index.jsx
+++ b/frontend-erp/src/modules/Producao/index.jsx
@@ -2,7 +2,7 @@
 import React from 'react';
 import { Routes, Route, Link, Outlet, useResolvedPath, useMatch } from 'react-router-dom';
 // Importa os componentes renomeados do AppProducao.jsx
-import { HomeProducao, LoteProducao, EditarPecaProducao, Pacote, Apontamento, ApontamentoVolume, EditarFerragem, Nesting } from './AppProducao';
+import { HomeProducao, LoteProducao, EditarPecaProducao, Pacote, Apontamento, ApontamentoVolume, EditarFerragem, Nesting, ConfigMaquina } from './AppProducao';
 
 function ProducaoLayout() {
   const resolved = useResolvedPath(''); // O caminho base para este módulo
@@ -60,6 +60,7 @@ function Producao() {
         <Route path="apontamento" element={<Apontamento />} />
         <Route path="apontamento-volume" element={<ApontamentoVolume />} />
         <Route path="nesting" element={<Nesting />} />
+        <Route path="nesting/config-maquina" element={<ConfigMaquina />} />
       </Route>
     </Routes>
   );

--- a/producao/backend/src/api.py
+++ b/producao/backend/src/api.py
@@ -109,10 +109,11 @@ async def executar_nesting(request: Request):
     pasta_lote = dados.get('pasta_lote')
     largura_chapa = float(dados.get('largura_chapa', 2750))
     altura_chapa = float(dados.get('altura_chapa', 1850))
+    ferramentas = dados.get('ferramentas', [])
     if not pasta_lote:
         return {"erro": "Parâmetro 'pasta_lote' não informado."}
     try:
-        pasta_resultado = gerar_nesting(pasta_lote, largura_chapa, altura_chapa)
+        pasta_resultado = gerar_nesting(pasta_lote, largura_chapa, altura_chapa, ferramentas)
     except Exception as e:
         return {"erro": str(e)}
     return {"status": "ok", "pasta_resultado": pasta_resultado}


### PR DESCRIPTION
## Summary
- add ConfigMaquina component to manage machine tools
- integrate tool list with Nesting component
- expose config screen via new route
- send selected tools to backend
- backend now accepts tools when generating nesting

## Testing
- `npm run lint` *(fails: cannot find module '@eslint/js')*
- `python -m py_compile producao/backend/src/nesting.py producao/backend/src/api.py`

------
https://chatgpt.com/codex/tasks/task_e_68594c39d860832db8d9cf267705b4b3