### PR TITLE
Add XML summary for generated plates

### DIFF
--- a/producao/backend/src/nesting.py
+++ b/producao/backend/src/nesting.py
@@ -63,6 +63,34 @@ def _gerar_cyc(chapas: List[List[Dict]], saida: Path):
         tree.write(saida / f'chapa_{i}.cyc', encoding='utf-8', xml_declaration=False)
 
 
+def _gerar_xml_chapas(
+    chapas: List[List[Dict]],
+    saida: Path,
+    largura_chapa: float,
+    altura_chapa: float,
+) -> None:
+    """Gera um XML listando todas as chapas otimizadas."""
+    root = ET.Element("CycleFile")
+    for i, pecas in enumerate(chapas, start=1):
+        cycle = ET.SubElement(root, "Cycle", Name="Cycle_List")
+        ET.SubElement(cycle, "Field", Name="PlateID", Value=f"chapa_{i}.nc")
+        ET.SubElement(cycle, "Field", Name="LabelName", Value=f"chapa_{i}.cyc")
+        ET.SubElement(cycle, "Field", Name="Height", Value=f"{altura_chapa:.3f}")
+        ET.SubElement(cycle, "Field", Name="Width", Value=f"{largura_chapa:.3f}")
+        thickness = 0
+        if pecas:
+            thickness = pecas[0].get("Thickness", 0)
+        ET.SubElement(cycle, "Field", Name="Thickness", Value=f"{int(thickness):02d}")
+        ET.SubElement(cycle, "Field", Name="LargeImage", Value=f"{i}.bmp")
+        ET.SubElement(cycle, "Field", Name="SmallImage", Value=f"{i}.bmp")
+    tree = ET.ElementTree(root)
+    try:
+        ET.indent(tree, space="  ")  # Python 3.9+
+    except AttributeError:
+        pass
+    tree.write(saida / "chapas.xml", encoding="utf-8", xml_declaration=True)
+
+
 def _gerar_gcodes(chapas: List[List[Dict]], saida: Path, ferramenta: dict | None = None):
     for i, pecas in enumerate(chapas, start=1):
         linhas = ['( Powered by Radha ERP )']
@@ -117,5 +145,6 @@ def gerar_nesting(pasta_lote: str, largura_chapa: float = 2750, altura_chapa: fl
 
     _gerar_gcodes(chapas, pasta_saida, ferramenta)
     _gerar_cyc(chapas, pasta_saida)
+    _gerar_xml_chapas(chapas, pasta_saida, largura_chapa, altura_chapa)
     return str(pasta_saida)
 


### PR DESCRIPTION
## Summary
- create `_gerar_xml_chapas` to output an XML summarizing all optimized plates
- call the new function from `gerar_nesting`

## Testing
- `python -m py_compile producao/backend/src/nesting.py`
- `PYTHONPATH=producao/backend/src python - <<'PY'
from nesting import gerar_nesting
print(gerar_nesting('producao/backend/src/saida/Lote_1'))
PY`

------
https://chatgpt.com/codex/tasks/task_e_685975ca7ac0832dacb6d737c64cb138