### PR TITLE
Enable machine settings during nesting

### DIFF
--- a/frontend-erp/src/modules/Producao/components/Nesting.jsx
+++ b/frontend-erp/src/modules/Producao/components/Nesting.jsx
@@ -44,6 +44,8 @@ const Nesting = () => {
   const executar = async () => {
     try {
       const ferramentas = JSON.parse(localStorage.getItem("ferramentasNesting") || "[]");
+      const configMaquina = JSON.parse(localStorage.getItem("configMaquina") || "null");
+      const configLayers = JSON.parse(localStorage.getItem("configLayers") || "[]");
       const data = await fetchComAuth("/executar-nesting", {
         method: "POST",
         body: JSON.stringify({
@@ -51,6 +53,8 @@ const Nesting = () => {
           largura_chapa: parseFloat(larguraChapa),
           altura_chapa: parseFloat(alturaChapa),
           ferramentas,
+          config_maquina: configMaquina,
+          config_layers: configLayers,
         }),
       });
       if (data?.erro) {

--- a/producao/backend/src/api.py
+++ b/producao/backend/src/api.py
@@ -127,10 +127,19 @@ async def executar_nesting(request: Request):
     largura_chapa = float(dados.get('largura_chapa', 2750))
     altura_chapa = float(dados.get('altura_chapa', 1850))
     ferramentas = dados.get('ferramentas', [])
+    config_maquina = dados.get('config_maquina')
+    config_layers = dados.get('config_layers')
     if not pasta_lote:
         return {"erro": "Parâmetro 'pasta_lote' não informado."}
     try:
-        pasta_resultado = gerar_nesting(pasta_lote, largura_chapa, altura_chapa, ferramentas)
+        pasta_resultado = gerar_nesting(
+            pasta_lote,
+            largura_chapa,
+            altura_chapa,
+            ferramentas,
+            config_layers,
+            config_maquina,
+        )
         layers = coletar_layers(pasta_lote)
     except Exception as e:
         return {"erro": str(e)}


### PR DESCRIPTION
## Summary
- send machine and layer config when executing nesting from the frontend
- include DXF filename when reading .dxt files
- generate gcode using machine and layer info
- accept configuration in `executar-nesting` endpoint

## Testing
- `python -m py_compile producao/backend/src/*.py`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6859925231b8832db2396f49d1739617