### PR TITLE
Implement deletion of lote folders

### DIFF
--- a/frontend-erp/src/modules/Producao/AppProducao.jsx
+++ b/frontend-erp/src/modules/Producao/AppProducao.jsx
@@ -30,11 +30,19 @@ const HomeProducao = () => {
     navigate(`lote/${nome}`);
   };
 
-  const excluirLote = (nome) => {
+  const excluirLote = async (nome) => {
     if (!window.confirm(`Tem certeza que deseja excluir o lote "${nome}"?`)) return;
     const atualizados = lotes.filter(l => l.nome !== nome);
     setLotes(atualizados);
     localStorage.setItem("lotesProducao", JSON.stringify(atualizados));
+    try {
+      await fetchComAuth("/excluir-lote", {
+        method: "POST",
+        body: JSON.stringify({ lote: nome })
+      });
+    } catch (e) {
+      console.error("Erro ao excluir lote no backend", e);
+    }
   };
 
   return (

--- a/frontend-erp/src/utils/fetchComAuth.js
+++ b/frontend-erp/src/utils/fetchComAuth.js
@@ -21,7 +21,7 @@ export async function fetchComAuth(url, options = {}) {
   if (url.startsWith('/')) { // Se for uma rota relativa
       if (url.startsWith('/publicos') || url.startsWith('/nova-campanha') || url.startsWith('/nova-publicacao') || url.startsWith('/chat') || url.startsWith('/conhecimento')) {
           finalUrl = `${GATEWAY_URL}/marketing-ia${url}`; // Rotas do Marketing Digital IA via Gateway
-      } else if (url.startsWith('/importar-xml') || url.startsWith('/gerar-lote-final') || url.startsWith('/executar-nesting') || url.startsWith('/listar-lotes')) {
+      } else if (url.startsWith('/importar-xml') || url.startsWith('/gerar-lote-final') || url.startsWith('/executar-nesting') || url.startsWith('/listar-lotes') || url.startsWith('/excluir-lote')) {
           finalUrl = `${GATEWAY_URL}/producao${url}`; // Rotas de Produção via Gateway
       } else if (url.startsWith('/auth')) {
           finalUrl = `${GATEWAY_URL}${url}`; // Endpoints de autenticação direto no Gateway

--- a/producao/backend/src/api.py
+++ b/producao/backend/src/api.py
@@ -7,6 +7,7 @@ from leitor_dxf import aplicar_usinagem_retangular
 from gerador_dxf import gerar_dxf_base
 from pathlib import Path
 import tempfile
+import shutil
 from operacoes import (
     parse_xml_orcamento,
     parse_xml_producao,
@@ -154,3 +155,17 @@ async def listar_lotes():
         return {"lotes": []}
     lotes = [str(p) for p in sorted(base.iterdir(), key=lambda x: x.name) if p.is_dir() and p.name.startswith("Lote_")]
     return {"lotes": lotes}
+
+
+@app.post("/excluir-lote")
+async def excluir_lote(request: Request):
+    """Remove a pasta do lote em 'saida'."""
+    dados = await request.json()
+    numero_lote = dados.get("lote")
+    if not numero_lote:
+        return {"erro": "Parâmetro 'lote' não informado."}
+    pasta = Path("saida") / f"Lote_{numero_lote}"
+    if pasta.is_dir():
+        shutil.rmtree(pasta, ignore_errors=True)
+        return {"status": "ok", "mensagem": f"Lote {numero_lote} removido"}
+    return {"status": "ok", "mensagem": "Lote não encontrado"}


### PR DESCRIPTION
## Summary
- add endpoint `/excluir-lote` to remove lote folders in production backend
- route `/excluir-lote` via `fetchComAuth`
- call backend when deleting a lote in production frontend

## Testing
- `python -m py_compile producao/backend/src/api.py`
- `npm test --prefix frontend-erp` *(fails: Missing script)*
- `npm run lint --prefix frontend-erp` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6859954419a8832db225fdadbe32a9d8