### PR TITLE
Ensure machine settings persist between sessions

### DIFF
--- a/frontend-erp/src/modules/Producao/components/ConfigMaquina.jsx
+++ b/frontend-erp/src/modules/Producao/components/ConfigMaquina.jsx
@@ -146,6 +146,22 @@ const ConfigMaquina = () => {
     setLayers(cfgLayers);
   }, []);
 
+  useEffect(() => {
+    localStorage.setItem("ferramentasNesting", JSON.stringify(ferramentas));
+  }, [ferramentas]);
+
+  useEffect(() => {
+    localStorage.setItem("configuracoesCorte", JSON.stringify(cortes));
+  }, [cortes]);
+
+  useEffect(() => {
+    localStorage.setItem("configMaquina", JSON.stringify(configMaquina));
+  }, [configMaquina]);
+
+  useEffect(() => {
+    localStorage.setItem("configLayers", JSON.stringify(layers));
+  }, [layers]);
+
   const salvarLS = (dados) => {
     setFerramentas(dados);
     localStorage.setItem("ferramentasNesting", JSON.stringify(dados));


### PR DESCRIPTION
## Summary
- keep `ConfigMaquina` state in localStorage whenever it changes

## Testing
- `npm run lint` *(fails: 'no-unused-vars' and 'Mixed spaces and tabs' in existing files)*

------
https://chatgpt.com/codex/tasks/task_e_685998a9ab44832dab2c90f280c69295