### PR TITLE
Add sheet image generation

### DIFF
--- a/producao/backend/src/requirements.txt
+++ b/producao/backend/src/requirements.txt
@@ -2,3 +2,4 @@ fastapi
 uvicorn
 ezdxf
 rectpack
+Pillow


### PR DESCRIPTION
## Summary
- generate per-sheet images when executing nesting
- handle transformations from ETIQUETADORA - Chapa config
- require Pillow library for backend

## Testing
- `pip install -r producao/backend/src/requirements.txt`
- `python -m py_compile producao/backend/src/nesting.py`

------
https://chatgpt.com/codex/tasks/task_e_68599dea7684832dbdd9567d963d2fca