### PR TITLE
Persist machine config

### DIFF
--- a/frontend-erp/src/modules/Producao/components/ConfigMaquina.jsx
+++ b/frontend-erp/src/modules/Producao/components/ConfigMaquina.jsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from "react";
 import { Button } from "./ui/button";
+import { fetchComAuth } from "../../../utils/fetchComAuth";
 
 const modeloFerramenta = {
   tipo: "Fresa",
@@ -140,10 +141,19 @@ const ConfigMaquina = () => {
     setFerramentas(salvas);
     const cfgCortes = JSON.parse(localStorage.getItem("configuracoesCorte") || "[]");
     setCortes(cfgCortes);
-    const cfgMaquina = JSON.parse(localStorage.getItem("configMaquina") || "null");
-    if (cfgMaquina) setConfigMaquina(cfgMaquina);
+    const cfgMaquinaLocal = JSON.parse(localStorage.getItem("configMaquina") || "null");
+    if (cfgMaquinaLocal) setConfigMaquina(cfgMaquinaLocal);
     const cfgLayers = JSON.parse(localStorage.getItem("configLayers") || "[]");
     setLayers(cfgLayers);
+
+    fetchComAuth('/config-maquina')
+      .then((data) => {
+        if (data) {
+          setConfigMaquina(data);
+          localStorage.setItem('configMaquina', JSON.stringify(data));
+        }
+      })
+      .catch((err) => console.error('Erro ao carregar configuracao da maquina', err));
   }, []);
 
   useEffect(() => {
@@ -274,8 +284,18 @@ const ConfigMaquina = () => {
     setMostrarFormCorte(false);
   };
 
-  const salvarConfig = () => {
-    salvarConfigMaquinaLS({ ...configMaquina });
+  const salvarConfig = async () => {
+    try {
+      await fetchComAuth('/config-maquina', {
+        method: 'POST',
+        body: JSON.stringify(configMaquina),
+      });
+      salvarConfigMaquinaLS({ ...configMaquina });
+      alert('Configuração salva com sucesso');
+    } catch (err) {
+      console.error('Erro ao salvar configuração', err);
+      alert('Erro ao salvar configuração: ' + err.message);
+    }
   };
 
   const handle = (campo) => (e) => setForm({ ...form, [campo]: e.target.value });

--- a/frontend-erp/src/utils/fetchComAuth.js
+++ b/frontend-erp/src/utils/fetchComAuth.js
@@ -21,7 +21,7 @@ export async function fetchComAuth(url, options = {}) {
   if (url.startsWith('/')) { // Se for uma rota relativa
       if (url.startsWith('/publicos') || url.startsWith('/nova-campanha') || url.startsWith('/nova-publicacao') || url.startsWith('/chat') || url.startsWith('/conhecimento')) {
           finalUrl = `${GATEWAY_URL}/marketing-ia${url}`; // Rotas do Marketing Digital IA via Gateway
-      } else if (url.startsWith('/importar-xml') || url.startsWith('/gerar-lote-final') || url.startsWith('/executar-nesting') || url.startsWith('/listar-lotes') || url.startsWith('/excluir-lote')) {
+      } else if (url.startsWith('/importar-xml') || url.startsWith('/gerar-lote-final') || url.startsWith('/executar-nesting') || url.startsWith('/listar-lotes') || url.startsWith('/excluir-lote') || url.startsWith('/config-maquina')) {
           finalUrl = `${GATEWAY_URL}/producao${url}`; // Rotas de Produção via Gateway
       } else if (url.startsWith('/auth')) {
           finalUrl = `${GATEWAY_URL}${url}`; // Endpoints de autenticação direto no Gateway


### PR DESCRIPTION
## Summary
- add config machine endpoints in production backend
- route `fetchComAuth` requests to new endpoints
- sync ConfigMaquina with backend

## Testing
- `npm run lint` *(fails: ESLint errors)*
- `python -m py_compile api.py`

------
https://chatgpt.com/codex/tasks/task_e_6859aae4829c832d801fb78e034c09bc