### PR TITLE
Implement etiqueta layout editor and generation

### DIFF
--- a/frontend-erp/src/modules/Producao/components/ConfigMaquina.jsx
+++ b/frontend-erp/src/modules/Producao/components/ConfigMaquina.jsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from "react";
 import { Button } from "./ui/button";
 import { fetchComAuth } from "../../../utils/fetchComAuth";
+import EtiquetaDesigner from "./EtiquetaDesigner";
 
 const modeloFerramenta = {
   tipo: "Fresa",
@@ -70,6 +71,7 @@ const modeloConfigMaquina = {
   rotacionarEtiquetaHorario: false,
   tamanhoMinimoPeca: "",
   mostrarNomeMaterial: false,
+  layoutEtiqueta: [],
   // REFERENCIAS
   xHoming: "",
   yHoming: "",
@@ -190,6 +192,10 @@ const ConfigMaquina = () => {
   const salvarLayersLS = (dados) => {
     setLayers(dados);
     localStorage.setItem("configLayers", JSON.stringify(dados));
+  };
+
+  const updateLayoutEtiqueta = (dados) => {
+    setConfigMaquina((c) => ({ ...c, layoutEtiqueta: dados }));
   };
 
   const novo = () => {
@@ -471,6 +477,15 @@ const ConfigMaquina = () => {
             <input type="checkbox" checked={configMaquina.mostrarNomeMaterial} onChange={handleConfig('mostrarNomeMaterial')} />
             <span className="text-sm">Mostrar nome completo do material (longo)</span>
           </label>
+          <div>
+            <h4 className="font-medium mb-1">Layout da Etiqueta</h4>
+            <EtiquetaDesigner
+              layout={configMaquina.layoutEtiqueta || []}
+              onChange={updateLayoutEtiqueta}
+              largura={configMaquina.tamanhoEtiquetadoraX}
+              altura={configMaquina.tamanhoEtiquetadoraY}
+            />
+          </div>
         </div>
 
         <div className="border p-4 rounded space-y-2">

--- a/frontend-erp/src/modules/Producao/components/EtiquetaDesigner.jsx
+++ b/frontend-erp/src/modules/Producao/components/EtiquetaDesigner.jsx
@@ -1,0 +1,93 @@
+import React, { useState } from 'react';
+import { Button } from './ui/button';
+
+const CAMPOS_DXT = [
+  'PartName',
+  'Length',
+  'Width',
+  'Thickness',
+  'Material',
+  'Program1',
+  'Filename',
+  'Client',
+  'Project',
+  'Comment'
+];
+
+const SCALE = 3; // pixels per mm
+
+const EtiquetaDesigner = ({ layout = [], onChange, largura = 50, altura = 30 }) => {
+  const [campo, setCampo] = useState('');
+  const [arrastando, setArrastando] = useState(null);
+
+  const adicionar = () => {
+    if (!campo) return;
+    const novo = { id: Date.now(), campo, x: 0, y: 0 };
+    onChange([...layout, novo]);
+    setCampo('');
+  };
+
+  const iniciarArraste = (id) => (e) => {
+    const rect = e.target.getBoundingClientRect();
+    setArrastando({
+      id,
+      offsetX: e.clientX - rect.left,
+      offsetY: e.clientY - rect.top
+    });
+  };
+
+  const mover = (e) => {
+    if (!arrastando) return;
+    const container = e.currentTarget.getBoundingClientRect();
+    const x = (e.clientX - container.left - arrastando.offsetX) / SCALE;
+    const y = (e.clientY - container.top - arrastando.offsetY) / SCALE;
+    onChange(
+      layout.map((it) => (it.id === arrastando.id ? { ...it, x, y } : it))
+    );
+  };
+
+  const parar = () => setArrastando(null);
+
+  const remover = (id) => {
+    onChange(layout.filter((it) => it.id !== id));
+  };
+
+  const larguraPx = parseFloat(largura || 50) * SCALE;
+  const alturaPx = parseFloat(altura || 30) * SCALE;
+
+  const disponiveis = CAMPOS_DXT.filter((c) => !layout.some((l) => l.campo === c));
+
+  return (
+    <div>
+      <div className="flex items-end gap-2 mb-2">
+        <select className="input" value={campo} onChange={(e) => setCampo(e.target.value)}>
+          <option value="">Adicionar informação...</option>
+          {disponiveis.map((c) => (
+            <option key={c} value={c}>{c}</option>
+          ))}
+        </select>
+        <Button size="sm" onClick={adicionar}>Adicionar</Button>
+      </div>
+      <div
+        className="border relative bg-white"
+        style={{ width: larguraPx, height: alturaPx }}
+        onMouseMove={mover}
+        onMouseUp={parar}
+      >
+        {layout.map((it) => (
+          <div
+            key={it.id}
+            onMouseDown={iniciarArraste(it.id)}
+            className="absolute text-xs cursor-move bg-white px-1 border"
+            style={{ left: it.x * SCALE, top: it.y * SCALE }}
+          >
+            {it.campo}
+            <button onClick={() => remover(it.id)} className="ml-1 text-red-600">x</button>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default EtiquetaDesigner;

--- a/producao/backend/src/nesting.py
+++ b/producao/backend/src/nesting.py
@@ -177,6 +177,34 @@ def _gerar_imagens_chapas(
         img.save(saida / f"{i}.{ext}")
 
 
+def _gerar_etiquetas(
+    chapas: List[List[Dict]],
+    saida: Path,
+    config_maquina: dict | None = None,
+) -> None:
+    """Gera imagens das etiquetas conforme layout configurado."""
+    if not config_maquina or not config_maquina.get("layoutEtiqueta"):
+        return
+    layout = config_maquina.get("layoutEtiqueta", [])
+    largura = float(config_maquina.get("tamanhoEtiquetadoraX", 50))
+    altura = float(config_maquina.get("tamanhoEtiquetadoraY", 30))
+    escala = 4
+    ext = str(config_maquina.get("formatoImagemEtiqueta", "bmp")).lower()
+    for p in [pc for placa in chapas for pc in placa]:
+        img = Image.new("RGB", (int(largura * escala), int(altura * escala)), "white")
+        draw = ImageDraw.Draw(img)
+        for item in layout:
+            campo = item.get("campo")
+            if not campo:
+                continue
+            valor = p.get(campo, "")
+            x = float(item.get("x", 0)) * escala
+            y = float(item.get("y", 0)) * escala
+            draw.text((x, y), str(valor), fill="black")
+        nome = Path(p.get("Filename", p.get("PartName", "etiqueta"))).stem
+        img.save(saida / f"{nome}.{ext}")
+
+
 def _gerar_gcodes(
     chapas: List[List[Dict]],
     saida: Path,
@@ -358,6 +386,11 @@ def gerar_nesting(
         pasta_saida,
         largura_chapa,
         altura_chapa,
+        config_maquina,
+    )
+    _gerar_etiquetas(
+        chapas,
+        pasta_saida,
         config_maquina,
     )
     return str(pasta_saida)


### PR DESCRIPTION
## Summary
- add `EtiquetaDesigner` component for visual label layout editing
- store `layoutEtiqueta` in machine config and embed editor in ConfigMaquina UI
- generate label images during nesting using configured layout

## Testing
- `npm run lint` *(fails: Mixed spaces and tabs and other pre-existing errors)*

------
https://chatgpt.com/codex/tasks/task_e_6859af8f93e8832da035ba91985b9bc4