### PR TITLE
Add SQLite persistence for production module

### DIFF
--- a/producao/backend/src/database.py
+++ b/producao/backend/src/database.py
@@ -1,0 +1,30 @@
+import sqlite3
+from pathlib import Path
+
+DB_PATH = Path(__file__).resolve().parent / "producao.db"
+
+
+def get_db_connection():
+    conn = sqlite3.connect(DB_PATH)
+    conn.row_factory = sqlite3.Row
+    return conn
+
+
+def init_db():
+    conn = get_db_connection()
+    cur = conn.cursor()
+    cur.execute(
+        "CREATE TABLE IF NOT EXISTS config_maquina (id INTEGER PRIMARY KEY CHECK (id = 1), dados TEXT)"
+    )
+    cur.execute(
+        """CREATE TABLE IF NOT EXISTS lotes (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            pasta TEXT UNIQUE,
+            criado_em TEXT
+        )"""
+    )
+    conn.commit()
+    conn.close()
+
+
+init_db()


### PR DESCRIPTION
## Summary
- add SQLite database helper for producao backend
- persist `config-maquina` and lot folders using SQLite

## Testing
- `python -m py_compile producao/backend/src/api.py producao/backend/src/database.py`

------
https://chatgpt.com/codex/tasks/task_e_6859bafe0330832daae9683f1399cf6a