### PR TITLE
Fix persistence for production configs

### DIFF
--- a/frontend-erp/src/modules/Producao/components/ConfigMaquina.jsx
+++ b/frontend-erp/src/modules/Producao/components/ConfigMaquina.jsx
@@ -156,6 +156,33 @@ const ConfigMaquina = () => {
         }
       })
       .catch((err) => console.error('Erro ao carregar configuracao da maquina', err));
+
+    fetchComAuth('/config-ferramentas')
+      .then((data) => {
+        if (Array.isArray(data)) {
+          setFerramentas(data);
+          localStorage.setItem('ferramentasNesting', JSON.stringify(data));
+        }
+      })
+      .catch((err) => console.error('Erro ao carregar ferramentas', err));
+
+    fetchComAuth('/config-cortes')
+      .then((data) => {
+        if (Array.isArray(data)) {
+          setCortes(data);
+          localStorage.setItem('configuracoesCorte', JSON.stringify(data));
+        }
+      })
+      .catch((err) => console.error('Erro ao carregar configuracoes de corte', err));
+
+    fetchComAuth('/config-layers')
+      .then((data) => {
+        if (Array.isArray(data)) {
+          setLayers(data);
+          localStorage.setItem('configLayers', JSON.stringify(data));
+        }
+      })
+      .catch((err) => console.error('Erro ao carregar layers', err));
   }, []);
 
   useEffect(() => {
@@ -177,11 +204,19 @@ const ConfigMaquina = () => {
   const salvarLS = (dados) => {
     setFerramentas(dados);
     localStorage.setItem("ferramentasNesting", JSON.stringify(dados));
+    fetchComAuth('/config-ferramentas', {
+      method: 'POST',
+      body: JSON.stringify(dados),
+    }).catch((err) => console.error('Erro ao salvar ferramentas', err));
   };
 
   const salvarCortesLS = (dados) => {
     setCortes(dados);
     localStorage.setItem("configuracoesCorte", JSON.stringify(dados));
+    fetchComAuth('/config-cortes', {
+      method: 'POST',
+      body: JSON.stringify(dados),
+    }).catch((err) => console.error('Erro ao salvar cortes', err));
   };
 
   const salvarConfigMaquinaLS = (dados) => {
@@ -192,6 +227,10 @@ const ConfigMaquina = () => {
   const salvarLayersLS = (dados) => {
     setLayers(dados);
     localStorage.setItem("configLayers", JSON.stringify(dados));
+    fetchComAuth('/config-layers', {
+      method: 'POST',
+      body: JSON.stringify(dados),
+    }).catch((err) => console.error('Erro ao salvar layers', err));
   };
 
   const updateLayoutEtiqueta = (dados) => {

--- a/frontend-erp/src/utils/fetchComAuth.js
+++ b/frontend-erp/src/utils/fetchComAuth.js
@@ -21,9 +21,9 @@ export async function fetchComAuth(url, options = {}) {
   if (url.startsWith('/')) { // Se for uma rota relativa
       if (url.startsWith('/publicos') || url.startsWith('/nova-campanha') || url.startsWith('/nova-publicacao') || url.startsWith('/chat') || url.startsWith('/conhecimento')) {
           finalUrl = `${GATEWAY_URL}/marketing-ia${url}`; // Rotas do Marketing Digital IA via Gateway
-      } else if (url.startsWith('/importar-xml') || url.startsWith('/gerar-lote-final') || url.startsWith('/executar-nesting') || url.startsWith('/listar-lotes') || url.startsWith('/excluir-lote') || url.startsWith('/config-maquina')) {
-          finalUrl = `${GATEWAY_URL}/producao${url}`; // Rotas de Produção via Gateway
-      } else if (url.startsWith('/auth')) {
+        } else if (url.startsWith('/importar-xml') || url.startsWith('/gerar-lote-final') || url.startsWith('/executar-nesting') || url.startsWith('/listar-lotes') || url.startsWith('/excluir-lote') || url.startsWith('/config-maquina') || url.startsWith('/config-ferramentas') || url.startsWith('/config-cortes') || url.startsWith('/config-layers')) {
+            finalUrl = `${GATEWAY_URL}/producao${url}`; // Rotas de Produção via Gateway
+        } else if (url.startsWith('/auth')) {
           finalUrl = `${GATEWAY_URL}${url}`; // Endpoints de autenticação direto no Gateway
       }
   } else {

--- a/producao/backend/src/api.py
+++ b/producao/backend/src/api.py
@@ -225,3 +225,102 @@ async def salvar_config_maquina(request: Request):
     except Exception as e:
         return {"erro": str(e)}
     return {"status": "ok"}
+
+
+# Novos endpoints para persistir ferramentas, configuracoes de corte e layers
+
+
+@app.get("/config-ferramentas")
+async def obter_ferramentas():
+    """Retorna a lista de ferramentas salva."""
+    try:
+        with get_db_connection() as conn:
+            row = conn.execute(
+                "SELECT dados FROM config_ferramentas WHERE id=1"
+            ).fetchone()
+            if row:
+                return json.loads(row["dados"])
+    except Exception as e:
+        return {"erro": str(e)}
+    return []
+
+
+@app.post("/config-ferramentas")
+async def salvar_ferramentas(request: Request):
+    """Salva lista de ferramentas no banco de dados."""
+    dados = await request.json()
+    try:
+        with get_db_connection() as conn:
+            conn.execute(
+                "INSERT INTO config_ferramentas (id, dados) VALUES (1, ?) "
+                "ON CONFLICT(id) DO UPDATE SET dados=excluded.dados",
+                (json.dumps(dados, ensure_ascii=False),),
+            )
+            conn.commit()
+    except Exception as e:
+        return {"erro": str(e)}
+    return {"status": "ok"}
+
+
+@app.get("/config-cortes")
+async def obter_cortes():
+    """Retorna as configuracoes de corte salvas."""
+    try:
+        with get_db_connection() as conn:
+            row = conn.execute(
+                "SELECT dados FROM config_cortes WHERE id=1"
+            ).fetchone()
+            if row:
+                return json.loads(row["dados"])
+    except Exception as e:
+        return {"erro": str(e)}
+    return []
+
+
+@app.post("/config-cortes")
+async def salvar_cortes(request: Request):
+    """Salva configuracoes de corte no banco de dados."""
+    dados = await request.json()
+    try:
+        with get_db_connection() as conn:
+            conn.execute(
+                "INSERT INTO config_cortes (id, dados) VALUES (1, ?) "
+                "ON CONFLICT(id) DO UPDATE SET dados=excluded.dados",
+                (json.dumps(dados, ensure_ascii=False),),
+            )
+            conn.commit()
+    except Exception as e:
+        return {"erro": str(e)}
+    return {"status": "ok"}
+
+
+@app.get("/config-layers")
+async def obter_layers():
+    """Retorna configuracoes de layers salvas."""
+    try:
+        with get_db_connection() as conn:
+            row = conn.execute(
+                "SELECT dados FROM config_layers WHERE id=1"
+            ).fetchone()
+            if row:
+                return json.loads(row["dados"])
+    except Exception as e:
+        return {"erro": str(e)}
+    return []
+
+
+@app.post("/config-layers")
+async def salvar_layers(request: Request):
+    """Salva configuracoes de layers no banco de dados."""
+    dados = await request.json()
+    try:
+        with get_db_connection() as conn:
+            conn.execute(
+                "INSERT INTO config_layers (id, dados) VALUES (1, ?) "
+                "ON CONFLICT(id) DO UPDATE SET dados=excluded.dados",
+                (json.dumps(dados, ensure_ascii=False),),
+            )
+            conn.commit()
+    except Exception as e:
+        return {"erro": str(e)}
+    return {"status": "ok"}

--- a/producao/backend/src/database.py
+++ b/producao/backend/src/database.py
@@ -17,6 +17,15 @@ def init_db():
         "CREATE TABLE IF NOT EXISTS config_maquina (id INTEGER PRIMARY KEY CHECK (id = 1), dados TEXT)"
     )
     cur.execute(
+        "CREATE TABLE IF NOT EXISTS config_ferramentas (id INTEGER PRIMARY KEY CHECK (id = 1), dados TEXT)"
+    )
+    cur.execute(
+        "CREATE TABLE IF NOT EXISTS config_cortes (id INTEGER PRIMARY KEY CHECK (id = 1), dados TEXT)"
+    )
+    cur.execute(
+        "CREATE TABLE IF NOT EXISTS config_layers (id INTEGER PRIMARY KEY CHECK (id = 1), dados TEXT)"
+    )
+    cur.execute(
         """CREATE TABLE IF NOT EXISTS lotes (
             id INTEGER PRIMARY KEY AUTOINCREMENT,
             pasta TEXT UNIQUE,


### PR DESCRIPTION
## Summary
- persist ferramentas, cortes and layers in backend
- sync frontend config with new persistence APIs
- route new endpoints via gateway

## Testing
- `python -m py_compile producao/backend/src/*.py`
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6859bcfccde8832d9b5d81b4d4711ebf