### PR TITLE
Fix drill edit action

### DIFF
--- a/frontend-erp/src/modules/Producao/components/ConfigMaquina.jsx
+++ b/frontend-erp/src/modules/Producao/components/ConfigMaquina.jsx
@@ -818,13 +818,23 @@ const ConfigMaquina = () => {
         <div>
           <h3 className="font-semibold">Fresas</h3>
           <ul className="space-y-1">
-            {ferramentas.filter(f => f.tipo === 'Fresa').map((f, i) => <Item f={f} i={i} key={i} />)}
+            {ferramentas
+              .filter(f => f.tipo === 'Fresa')
+              .map(f => {
+                const idx = ferramentas.indexOf(f);
+                return <Item f={f} i={idx} key={idx} />;
+              })}
           </ul>
         </div>
         <div>
           <h3 className="font-semibold">Brocas</h3>
           <ul className="space-y-1">
-            {ferramentas.filter(f => f.tipo === 'Broca').map((f, i) => <Item f={f} i={i} key={i} />)}
+            {ferramentas
+              .filter(f => f.tipo === 'Broca')
+              .map(f => {
+                const idx = ferramentas.indexOf(f);
+                return <Item f={f} i={idx} key={idx} />;
+              })}
           </ul>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- correctly pass index for drill edit buttons so the selected tool is opened

## Testing
- `npm install` in `frontend-erp`
- `npm run lint` *(fails: many existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_685a880359c4832d929092fad91d9bfb