### PR TITLE
Fix chapas save routing

### DIFF
--- a/frontend-erp/src/utils/fetchComAuth.js
+++ b/frontend-erp/src/utils/fetchComAuth.js
@@ -21,7 +21,7 @@ export async function fetchComAuth(url, options = {}) {
   if (url.startsWith('/')) { // Se for uma rota relativa
       if (url.startsWith('/publicos') || url.startsWith('/nova-campanha') || url.startsWith('/nova-publicacao') || url.startsWith('/chat') || url.startsWith('/conhecimento')) {
           finalUrl = `${GATEWAY_URL}/marketing-ia${url}`; // Rotas do Marketing Digital IA via Gateway
-        } else if (url.startsWith('/importar-xml') || url.startsWith('/gerar-lote-final') || url.startsWith('/executar-nesting') || url.startsWith('/listar-lotes') || url.startsWith('/excluir-lote') || url.startsWith('/config-maquina') || url.startsWith('/config-ferramentas') || url.startsWith('/config-cortes') || url.startsWith('/config-layers')) {
+        } else if (url.startsWith('/importar-xml') || url.startsWith('/gerar-lote-final') || url.startsWith('/executar-nesting') || url.startsWith('/listar-lotes') || url.startsWith('/excluir-lote') || url.startsWith('/config-maquina') || url.startsWith('/config-ferramentas') || url.startsWith('/config-cortes') || url.startsWith('/config-layers') || url.startsWith('/chapas')) {
             finalUrl = `${GATEWAY_URL}/producao${url}`; // Rotas de Produção via Gateway
         } else if (url.startsWith('/auth')) {
           finalUrl = `${GATEWAY_URL}${url}`; // Endpoints de autenticação direto no Gateway


### PR DESCRIPTION
## Summary
- route `/chapas` requests through the gateway so the save operation works

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685ad2e7d9c8832d9c3ab5eaca1120b9