### PR TITLE
Implement layer filtering and CHAPA metadata

### DIFF
--- a/producao/backend/src/api.py
+++ b/producao/backend/src/api.py
@@ -35,13 +35,13 @@ def coletar_layers(pasta_lote: str) -> list[str]:
             # Inclui também os layers definidos no arquivo, não apenas os utilizados
             for layer in doc.layers:
                 nome = layer.dxf.name
-                if nome and nome.upper() != "CONTORNO":
+                if nome and nome.upper() not in {"CONTORNO", "0", "DEFPOINTS"}:
                     layers.add(nome)
 
             msp = doc.modelspace()
             for ent in msp:
                 nome = ent.dxf.layer
-                if nome and nome.upper() != "CONTORNO":
+                if nome and nome.upper() not in {"CONTORNO", "0", "DEFPOINTS"}:
                     layers.add(nome)
 
     return sorted(layers)

--- a/producao/backend/src/nesting.py
+++ b/producao/backend/src/nesting.py
@@ -8,6 +8,7 @@ from shapely.ops import unary_union
 
 from rectpack import newPacker
 import ezdxf
+import math
 from PIL import Image, ImageDraw
 from database import get_db_connection
 
@@ -353,7 +354,7 @@ def _gerar_gcodes(
 
     for i, pecas in enumerate(chapas, start=1):
         material = pecas[0].get('Material', 'chapa') if pecas else 'chapa'
-        thickness = int(pecas[0].get('Thickness', 0)) if pecas else 0
+        thickness = float(pecas[0].get('Thickness', 0)) if pecas else 0.0
         prefix = f"{i:03d}-MDF {thickness}mm {material}"
 
         valores_intro = {
@@ -378,6 +379,8 @@ def _gerar_gcodes(
             'CMD_EXTRA': primeira_ferramenta.get('comandoExtra', '') if primeira_ferramenta else '',
         }
         linhas.extend(substituir(header_tpl, valores_header).splitlines())
+        camada_chapa = f"CHAPA_{math.floor(thickness):.1f}"
+        linhas.append(f"({camada_chapa})")
 
         for p in pecas:
             dxf_path = None


### PR DESCRIPTION
## Summary
- ignore DXF layers `0` and `Defpoints`
- annotate generated NC files with a `CHAPA_X` comment that reflects board thickness

## Testing
- `python -m py_compile producao/backend/src/api.py producao/backend/src/nesting.py`


------
https://chatgpt.com/codex/tasks/task_e_685ae8e46bac832daad7ca6c2cf45a8a