### PR TITLE
Implementa módulo de lotes de ocorrências

### DIFF
--- a/producao/backend/src/database.py
+++ b/producao/backend/src/database.py
@@ -42,6 +42,16 @@ def init_db():
             criado_em TEXT
         )"""
     )
+    cur.execute(
+        """CREATE TABLE IF NOT EXISTS lotes_ocorrencias (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            lote TEXT,
+            pacote TEXT,
+            oc_numero INTEGER UNIQUE,
+            pasta TEXT,
+            criado_em TEXT
+        )"""
+    )
     conn.commit()
     conn.close()
 


### PR DESCRIPTION
## Summary
- cria tabela `lotes_ocorrencias`
- adiciona utilitário para gerar número sequencial de OC
- adiciona endpoints REST para manipular lotes de ocorrências

## Testing
- `python -m py_compile producao/backend/src/api.py producao/backend/src/database.py`

------
https://chatgpt.com/codex/tasks/task_e_685c0393442c832d8224a479fd97af2b