### PR TITLE
Handle occurrence package editing correctly

### DIFF
--- a/frontend-erp/src/modules/Producao/AppProducao.jsx
+++ b/frontend-erp/src/modules/Producao/AppProducao.jsx
@@ -159,6 +159,7 @@ const EditarPecaProducao = () => {
   const navigate = useNavigate();
   const location = useLocation();
   const origemOcorrencia = location.state?.origem === "ocorrencia";
+  const ocId = location.state?.ocId;
 
   const [dadosPeca, setDadosPeca] = useState(null);
   const [operacoes, setOperacoes] = useState([]);
@@ -168,20 +169,26 @@ const EditarPecaProducao = () => {
   const [novaLargura, setNovaLargura] = useState("");
 
   useEffect(() => {
-    const lotes = JSON.parse(localStorage.getItem("lotesProducao") || "[]");
     let pecaEncontrada = null;
 
-    for (const l of lotes) {
-      if (l.nome === nome) {
-        for (const pacote of l.pacotes || []) {
-          const p = pacote.pecas.find((p) => p.id === parseInt(pecaId));
-          if (p) {
-            pecaEncontrada = p;
-            break;
+    if (origemOcorrencia) {
+      const lotesOc = JSON.parse(localStorage.getItem("lotesOcorrenciaLocal") || "[]");
+      const lote = lotesOc.find((l) => l.id === ocId);
+      pecaEncontrada = lote?.pacoteData?.pecas?.find((p) => p.id === parseInt(pecaId));
+    } else {
+      const lotes = JSON.parse(localStorage.getItem("lotesProducao") || "[]");
+      for (const l of lotes) {
+        if (l.nome === nome) {
+          for (const pacote of l.pacotes || []) {
+            const p = pacote.pecas.find((p) => p.id === parseInt(pecaId));
+            if (p) {
+              pecaEncontrada = p;
+              break;
+            }
           }
         }
+        if (pecaEncontrada) break;
       }
-      if (pecaEncontrada) break;
     }
 
     if (pecaEncontrada) {
@@ -197,7 +204,7 @@ const EditarPecaProducao = () => {
       setNovoComprimento(dadosEditados?.comprimento || pecaEncontrada.comprimento);
       setNovaLargura(dadosEditados?.largura || pecaEncontrada.largura);
     }
-  }, [pecaId, nome, origemOcorrencia]);
+  }, [pecaId, nome, origemOcorrencia, ocId]);
 
   const salvarOperacao = () => {
     const pos = form.posicao;
@@ -469,7 +476,16 @@ const EditarPecaProducao = () => {
         }
         <div className="flex gap-2 mt-4">
           <Button onClick={salvarOperacao}>Salvar Operação</Button>
-          <Button variant="outline" onClick={() => navigate(`/producao/lote/${nome}`)}>Finalizar</Button>
+          <Button
+            variant="outline"
+            onClick={() =>
+              origemOcorrencia
+                ? navigate('/producao/ocorrencias', { state: { ocId } })
+                : navigate(`/producao/lote/${nome}`)
+            }
+          >
+            Finalizar
+          </Button>
           <Button variant="destructive" onClick={excluirTodas}>Excluir Todas</Button>
         </div>
 

--- a/frontend-erp/src/modules/Producao/components/LotesOcorrencia.jsx
+++ b/frontend-erp/src/modules/Producao/components/LotesOcorrencia.jsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from "react";
 import { Button } from "./ui/button";
-import { useNavigate } from "react-router-dom";
+import { useNavigate, useLocation } from "react-router-dom";
 import { fetchComAuth } from "../../../utils/fetchComAuth";
 import CadastroMotivos from "./CadastroMotivos";
 
@@ -18,6 +18,7 @@ const LotesOcorrencia = () => {
   const [lotesLocais, setLotesLocais] = useState([]);
   const [ocAtual, setOcAtual] = useState(null);
   const navigate = useNavigate();
+  const location = useLocation();
 
   useEffect(() => {
     fetchComAuth("/lotes-ocorrencias").then(setLotes).catch(() => {});
@@ -27,6 +28,14 @@ const LotesOcorrencia = () => {
     const loc = JSON.parse(localStorage.getItem("lotesOcorrenciaLocal") || "[]");
     setLotesLocais(loc);
   }, []);
+
+  useEffect(() => {
+    const id = location.state?.ocId;
+    if (id) {
+      editarLoteLocal(id);
+      navigate('.', { replace: true, state: {} });
+    }
+  }, [location.state]);
 
   useEffect(() => {
     const loteObj = lotesProducao.find((l) => l.nome === loteSel);
@@ -305,7 +314,7 @@ const LotesOcorrencia = () => {
                           </option>
                         ))}
                       </select>
-                      <Button onClick={() => navigate(`/producao/lote/${loteSel}/peca/${p.id}`)}>
+                      <Button onClick={() => navigate(`/producao/lote/${loteSel}/peca/${p.id}`, { state: { origem: 'ocorrencia', ocId: ocAtual } })}>
                         Editar
                       </Button>
                     </div>


### PR DESCRIPTION
## Summary
- track origin package when editing pieces
- auto-open copied package when returning to occurrence page
- keep edits confined to the copied occurrence package

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_685c29bb7154832d88a63d296052fe7e