### PR TITLE
Fix navigation for occurrence packages

### DIFF
--- a/frontend-erp/src/modules/Producao/components/LotesOcorrencia.jsx
+++ b/frontend-erp/src/modules/Producao/components/LotesOcorrencia.jsx
@@ -64,6 +64,9 @@ const LotesOcorrencia = () => {
     const pacoteObj = pacotesDisponiveis[parseInt(pacoteSel)];
     if (!pacoteObj) return;
     const copia = JSON.parse(JSON.stringify(pacoteObj));
+    let nextId = parseInt(localStorage.getItem("globalPecaIdProducao")) || 1;
+    copia.pecas = (copia.pecas || []).map((p) => ({ ...p, id: nextId++ }));
+    localStorage.setItem("globalPecaIdProducao", nextId);
     const id = Date.now();
     const novo = { id, lote: loteSel, pacote: pacoteSel, pacoteData: copia };
     salvarLotesLocais([...lotesLocais, novo]);

--- a/frontend-erp/src/modules/Producao/components/PacoteOcorrencia.jsx
+++ b/frontend-erp/src/modules/Producao/components/PacoteOcorrencia.jsx
@@ -122,11 +122,12 @@ const PacoteOcorrencia = () => {
                   ))}
                 </select>
                 <Button
-                  onClick={() =>
-                    navigate(`/producao/lote/${loteLocal.lote}/peca/${p.id}`, {
+                  onClick={() => {
+                    const nomeLote = loteLocal.lote.split(/[/\\\\]/).pop();
+                    navigate(`/producao/lote/${nomeLote}/peca/${p.id}`, {
                       state: { origem: "ocorrencia", ocId: loteLocal.id },
-                    })
-                  }
+                    });
+                  }}
                 >
                   Editar
                 </Button>


### PR DESCRIPTION
## Summary
- assign IDs when cloning occurrence packages
- fix navigation to occurrence pieces

## Testing
- `npm --prefix frontend-erp run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685c415651c8832d9055983108b7226d