### PR TITLE
Fix occurrence edit operations

### DIFF
--- a/frontend-erp/src/modules/Producao/AppProducao.jsx
+++ b/frontend-erp/src/modules/Producao/AppProducao.jsx
@@ -200,7 +200,12 @@ const EditarPecaProducao = () => {
       const chaveOp = origemOcorrencia
         ? "ocedit_op_" + pecaId
         : "op_producao_" + pecaId;
-      const operacoesSalvas = JSON.parse(localStorage.getItem(chaveOp) || "[]");
+      let operacoesSalvas = JSON.parse(localStorage.getItem(chaveOp) || "[]");
+      if (origemOcorrencia && operacoesSalvas.length === 0) {
+        operacoesSalvas = JSON.parse(
+          localStorage.getItem("op_producao_" + pecaId) || "[]"
+        );
+      }
       setOperacoes(operacoesSalvas);
       setNovoComprimento(dadosEditados?.comprimento || pecaEncontrada.comprimento);
       setNovaLargura(dadosEditados?.largura || pecaEncontrada.largura);

--- a/frontend-erp/src/modules/Producao/components/LotesOcorrencia.jsx
+++ b/frontend-erp/src/modules/Producao/components/LotesOcorrencia.jsx
@@ -65,7 +65,16 @@ const LotesOcorrencia = () => {
     if (!pacoteObj) return;
     const copia = JSON.parse(JSON.stringify(pacoteObj));
     let nextId = parseInt(localStorage.getItem("globalPecaIdProducao")) || 1;
-    copia.pecas = (copia.pecas || []).map((p) => ({ ...p, id: nextId++ }));
+    copia.pecas = (copia.pecas || []).map((p) => {
+      const novoId = nextId++;
+      if (p.operacoes) {
+        localStorage.setItem(
+          "op_producao_" + novoId,
+          JSON.stringify(p.operacoes)
+        );
+      }
+      return { ...p, id: novoId };
+    });
     localStorage.setItem("globalPecaIdProducao", nextId);
     const id = Date.now();
     const novo = { id, lote: loteSel, pacote: pacoteSel, pacoteData: copia };


### PR DESCRIPTION
## Summary
- ensure default operations show when editing peças from ocorrência
- save original operations when cloning pacote

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js' and other errors)*

------
https://chatgpt.com/codex/tasks/task_e_685c443f4594832d82b3829f746ce78c