### PR TITLE
Fix DXF generation log output

### DIFF
--- a/producao/backend/src/gerador_dxf.py
+++ b/producao/backend/src/gerador_dxf.py
@@ -20,7 +20,7 @@ def gerar_dxf_base(comprimento, largura, saida_path):
     polyline.close(True)
 
     doc.saveas(saida_path)
-    print(f"📄 Arquivo DXT gerado em: {nome_arquivo}")
+    print(f"📄 Arquivo DXT gerado em: {saida_path}")
 
 def gerar_dxt_final(pecas, pasta_saida, nome_lote):
     nome_arquivo = os.path.join(pasta_saida, f"{nome_lote}.dxt")


### PR DESCRIPTION
## Summary
- fix undefined variable in DXF generation

## Testing
- `PYTHONPATH=producao/backend/src python3 - <<'PY'
from fastapi.testclient import TestClient
from api import app
client = TestClient(app)
resp = client.post('/gerar-lote-final', json={'lote': '1', 'pecas':[{'id': 1,'comprimento': 10,'largura':10,'nome':'peca1','codigo_peca':'abc','operacoes':[]}]} )
print('status', resp.status_code)
print('body', resp.json())
PY`

------
https://chatgpt.com/codex/tasks/task_e_685c546bc618832dbc96183691e7f824