### PR TITLE
Fix door operation parsing

### DIFF
--- a/producao/backend/src/operacoes.py
+++ b/producao/backend/src/operacoes.py
@@ -329,11 +329,9 @@ def parse_dxt_producao(root, dxt_path):
             largura = float(item_data.get("Width", 0))
             espessura = float(item_data.get("Thickness", 0))
 
-            is_porta = "PORTA" in descricao_item or "FRENTE" in descricao_item
             operacoes_dxf = processar_dxf_producao(
                 caminho_dxf,
                 {"comprimento": comprimento, "largura": largura},
-                is_porta=is_porta,
             )
 
             operacoes_bpp = []
@@ -484,11 +482,9 @@ def parse_xml_producao(root, xml_path):
                 largura_xml = float(atributos.get("PROFUNDIDADE", "0"))
                 espessura = float(atributos.get("ALTURA", "0"))
 
-                is_porta = "PORTA" in descricao or "FRENTE" in descricao
                 operacoes_dxf = processar_dxf_producao(
                     caminho_dxf,
                     {"comprimento": comprimento_xml, "largura": largura_xml},
-                    is_porta=is_porta,
                 )
 
                 operacoes_bpp = []


### PR DESCRIPTION
## Summary
- fix door parsing logic to avoid swapping coordinates

## Testing
- `python -m py_compile producao/backend/src/operacoes.py`
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685c58de88e4832dab502bd4def2ef00