### PR TITLE
Fix cyc xml formatting

### DIFF
--- a/producao/backend/src/nesting.py
+++ b/producao/backend/src/nesting.py
@@ -254,7 +254,11 @@ def _gerar_cyc(chapas: List[List[Dict]], saida: Path):
             ET.SubElement(cycle, 'Field', Name='Y', Value=str(p['y'] + p['Width']/2))
             ET.SubElement(cycle, 'Field', Name='R', Value='0')
         tree = ET.ElementTree(root)
-        tree.write(saida / f'{prefix}.cyc', encoding='utf-8', xml_declaration=False)
+        try:
+            ET.indent(tree, space="  ")  # Python 3.9+
+        except AttributeError:
+            pass
+        tree.write(saida / f"{prefix}.cyc", encoding="utf-8", xml_declaration=True)
 
 
 def _gerar_xml_chapas(


### PR DESCRIPTION
## Summary
- add XML indentation when generating `*.cyc` files

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c67553bc0832d837853c2890e8b06