### PR TITLE
Add sidebar navigation and Cadastros module

### DIFF
--- a/frontend-erp/src/App.jsx
+++ b/frontend-erp/src/App.jsx
@@ -7,36 +7,61 @@ import {
   Navigate,
   useNavigate,
   Outlet,
+  useMatch,
 } from "react-router-dom";
 
 import MarketingDigitalIA from "./modules/MarketingDigitalIA";
 import Producao from "./modules/Producao";
+import Cadastros from "./modules/Cadastros";
 import Login from "./pages/Login";
 import { fetchComAuth } from "./utils/fetchComAuth";
 
 // Componente de Layout: A "moldura" do ERP para um usuário logado
 function Layout({ usuario, onLogout }) {
-  const possuiPermissao = (modulo) => {
-    return usuario?.permissoes?.includes(modulo);
-  };
+  const possuiPermissao = (modulo) => usuario?.permissoes?.includes(modulo);
+
+  const matchCadastros = useMatch("/cadastros/*");
+  const matchMarketing = useMatch("/marketing-ia/*");
+  const matchProducao = useMatch("/producao/*");
 
   return (
-    <div className="min-h-screen bg-gray-100 flex flex-col">
-    
-      <header className="bg-purple-900 text-white p-4 shadow-md flex justify-between items-center">
-        <h1 className="text-2xl font-bold">Radha ERP</h1>
-        <nav className="flex space-x-4">
+    <div className="min-h-screen flex">
+      <aside className="bg-blue-900 text-white p-4 flex flex-col w-[20%] min-w-[200px]">
+        <h1 className="text-2xl font-bold mb-6">Radha ERP</h1>
+        <nav className="flex flex-col space-y-2 flex-grow">
+          {possuiPermissao("cadastros") && (
+            <Link
+              to="/cadastros"
+              className={`px-2 py-1 rounded ${matchCadastros ? "bg-blue-700" : "hover:bg-blue-700"}`}
+            >
+              Cadastros
+            </Link>
+          )}
           {possuiPermissao("marketing-ia") && (
-            <Link to="/marketing-ia" className="hover:underline">Marketing Digital IA</Link>
+            <Link
+              to="/marketing-ia"
+              className={`px-2 py-1 rounded ${matchMarketing ? "bg-blue-700" : "hover:bg-blue-700"}`}
+            >
+              Marketing Digital IA
+            </Link>
           )}
           {possuiPermissao("producao") && (
-            <Link to="/producao" className="hover:underline">Produção</Link>
+            <Link
+              to="/producao"
+              className={`px-2 py-1 rounded ${matchProducao ? "bg-blue-700" : "hover:bg-blue-700"}`}
+            >
+              Produção
+            </Link>
           )}
         </nav>
-        <button onClick={onLogout} className="bg-red-500 hover:bg-red-600 text-white px-3 py-1 rounded">Sair</button>
-      </header>
-      <main className="flex-grow p-4">
-        {/* As páginas dos módulos (filhas da rota) serão renderizadas aqui */}
+        <button
+          onClick={onLogout}
+          className="bg-red-500 hover:bg-red-600 text-white px-3 py-1 rounded mt-4"
+        >
+          Sair
+        </button>
+      </aside>
+      <main className="flex-grow p-4 bg-gray-100">
         <Outlet />
       </main>
     </div>
@@ -118,6 +143,7 @@ function App() {
           }
         >
           <Route index element={<p className="text-center text-lg mt-10">Bem-vindo ao ERP Radha. Selecione um módulo no menu.</p>} />
+          <Route path="cadastros/*" element={<Cadastros />} />
           <Route path="marketing-ia/*" element={<MarketingDigitalIA />} />
           <Route path="producao/*" element={<Producao />} />
         </Route>

--- a/frontend-erp/src/modules/Cadastros/index.jsx
+++ b/frontend-erp/src/modules/Cadastros/index.jsx
@@ -1,0 +1,12 @@
+import React from 'react';
+
+function Cadastros() {
+  return (
+    <div className="p-4 bg-white rounded shadow-md">
+      <h2 className="text-xl font-bold mb-4 text-blue-700">Módulo: Cadastros</h2>
+      <p>Em construção...</p>
+    </div>
+  );
+}
+
+export default Cadastros;

--- a/frontend-erp/src/modules/MarketingDigitalIA/index.jsx
+++ b/frontend-erp/src/modules/MarketingDigitalIA/index.jsx
@@ -17,29 +17,29 @@ function MarketingDigitalIALayout() {
 
   return (
     <div className="p-4 bg-white rounded shadow-md">
-      <h2 className="text-xl font-bold mb-4 text-purple-700">Módulo: Marketing Digital IA</h2>
+      <h2 className="text-xl font-bold mb-4 text-blue-700">Módulo: Marketing Digital IA</h2>
       <nav className="flex gap-4 mb-4 border-b pb-2">
         <Link
           to="." // Relativo ao path do módulo (MarketingDigitalIA)
-          className={`px-3 py-1 rounded ${matchChat ? 'bg-purple-200 text-purple-800' : 'text-purple-600 hover:bg-purple-100'}`}
+          className={`px-3 py-1 rounded ${matchChat ? 'bg-blue-200 text-blue-800' : 'text-blue-600 hover:bg-blue-100'}`}
         >
           Assistente Sara
         </Link>
         <Link
           to="nova-campanha" // Relativo ao path do módulo
-          className={`px-3 py-1 rounded ${matchCampanha ? 'bg-purple-200 text-purple-800' : 'text-purple-600 hover:bg-purple-100'}`}
+          className={`px-3 py-1 rounded ${matchCampanha ? 'bg-blue-200 text-blue-800' : 'text-blue-600 hover:bg-blue-100'}`}
         >
           Nova Campanha
         </Link>
         <Link
           to="nova-publicacao" // Relativo ao path do módulo
-          className={`px-3 py-1 rounded ${matchPublicacao ? 'bg-purple-200 text-purple-800' : 'text-purple-600 hover:bg-purple-100'}`}
+          className={`px-3 py-1 rounded ${matchPublicacao ? 'bg-blue-200 text-blue-800' : 'text-blue-600 hover:bg-blue-100'}`}
         >
           Nova Publicação
         </Link>
         <Link
           to="publicos-alvo" // Relativo ao path do módulo
-          className={`px-3 py-1 rounded ${matchPublicos ? 'bg-purple-200 text-purple-800' : 'text-purple-600 hover:bg-purple-100'}`}
+          className={`px-3 py-1 rounded ${matchPublicos ? 'bg-blue-200 text-blue-800' : 'text-blue-600 hover:bg-blue-100'}`}
         >
           Públicos Alvo
         </Link>

--- a/frontend-erp/src/modules/MarketingDigitalIA/pages/Chat.jsx
+++ b/frontend-erp/src/modules/MarketingDigitalIA/pages/Chat.jsx
@@ -89,7 +89,7 @@ function Chat({ usuarioLogado }) {
         />
         <button
           type="submit"
-          className="bg-purple-600 text-white px-4 py-2 rounded hover:bg-purple-700"
+          className="bg-blue-600 text-white px-4 py-2 rounded hover:bg-blue-700"
           disabled={carregando}
         >
           Enviar

--- a/frontend-erp/src/modules/MarketingDigitalIA/pages/NovaCampanha.jsx
+++ b/frontend-erp/src/modules/MarketingDigitalIA/pages/NovaCampanha.jsx
@@ -106,7 +106,7 @@ function NovaCampanha() {
 
       <button
         onClick={enviar}
-        className="bg-purple-900 text-white px-4 py-2 rounded hover:bg-purple-700"
+        className="bg-blue-900 text-white px-4 py-2 rounded hover:bg-blue-700"
       >
         Criar Campanha
       </button>

--- a/frontend-erp/src/pages/Login.jsx
+++ b/frontend-erp/src/pages/Login.jsx
@@ -35,7 +35,7 @@ function Login({ onLoginSuccess }) {
   return (
     <div className="min-h-screen flex flex-col justify-center items-center bg-gray-100 p-6">
       <div className="max-w-md w-full bg-white p-8 rounded-lg shadow-lg">
-        <h2 className="text-3xl font-bold text-center text-purple-900 mb-8">
+        <h2 className="text-3xl font-bold text-center text-blue-900 mb-8">
           Login Radha ERP
         </h2>
         <form onSubmit={handleLogin} className="space-y-6">
@@ -51,7 +51,7 @@ function Login({ onLoginSuccess }) {
               id="username"
               value={username}
               onChange={(e) => setUsername(e.target.value)}
-              className="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm placeholder-gray-400 focus:outline-none focus:ring-purple-500 focus:border-purple-500 sm:text-sm"
+              className="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm placeholder-gray-400 focus:outline-none focus:ring-blue-500 focus:border-blue-500 sm:text-sm"
               placeholder="Seu usuário"
               required
             />
@@ -68,7 +68,7 @@ function Login({ onLoginSuccess }) {
               id="password"
               value={password}
               onChange={(e) => setPassword(e.target.value)}
-              className="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm placeholder-gray-400 focus:outline-none focus:ring-purple-500 focus:border-purple-500 sm:text-sm"
+              className="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm placeholder-gray-400 focus:outline-none focus:ring-blue-500 focus:border-blue-500 sm:text-sm"
               placeholder="Sua senha"
               required
             />
@@ -77,7 +77,7 @@ function Login({ onLoginSuccess }) {
           <div>
             <button
               type="submit"
-              className="w-full flex justify-center py-2 px-4 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-purple-800 hover:bg-purple-900 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-purple-500"
+              className="w-full flex justify-center py-2 px-4 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-blue-800 hover:bg-blue-900 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500"
             >
               Entrar
             </button>


### PR DESCRIPTION
## Summary
- create Cadastros module placeholder
- replace header layout with persistent sidebar navigation
- update routes to include Cadastros
- standardize colors to blue theme across login and Marketing Digital IA pages

## Testing
- `npm run lint` *(fails: no-unused-vars and other lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_685c7032a484832d9557cf60755341ab