### PR TITLE
Add Cadastro module with Dados da Empresa form

### DIFF
--- a/frontend-erp/src/modules/Cadastros/Cadastros.css
+++ b/frontend-erp/src/modules/Cadastros/Cadastros.css
@@ -1,0 +1,7 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+.input {
+  @apply border p-2 rounded w-full;
+}

--- a/frontend-erp/src/modules/Cadastros/DadosEmpresa.jsx
+++ b/frontend-erp/src/modules/Cadastros/DadosEmpresa.jsx
@@ -1,0 +1,149 @@
+import React, { useState, useEffect } from 'react';
+import { Button } from '../Producao/components/ui/button';
+import { fetchComAuth } from '../../utils/fetchComAuth';
+
+function gerarCodigo(nomeFantasia, sequencial) {
+  if (!nomeFantasia) return '';
+  const prefixo = nomeFantasia.trim().substring(0,3);
+  if (!prefixo) return '';
+  const formatado = prefixo[0].toUpperCase() + prefixo.slice(1).toLowerCase();
+  return `${formatado}${String(sequencial).padStart(3,'0')}`;
+}
+
+function DadosEmpresa() {
+  const [sequencial, setSequencial] = useState(1);
+  const [form, setForm] = useState({
+    razaoSocial: '',
+    nomeFantasia: '',
+    codigo: '',
+    cnpj: '',
+    inscricaoEstadual: '',
+    cep: '',
+    rua: '',
+    numero: '',
+    bairro: '',
+    cidade: '',
+    estado: '',
+    telefone1: '',
+    telefone2: '',
+    logo: null,
+  });
+
+  useEffect(() => {
+    const seq = parseInt(localStorage.getItem('empresaCodigoSeq') || '1', 10);
+    setSequencial(seq);
+  }, []);
+
+  useEffect(() => {
+    setForm(f => ({ ...f, codigo: gerarCodigo(f.nomeFantasia, sequencial) }));
+  }, [form.nomeFantasia, sequencial]);
+
+  const handle = campo => e => {
+    const value = campo === 'logo' ? e.target.files[0] : e.target.value;
+    setForm(prev => ({ ...prev, [campo]: value }));
+  };
+
+  const buscarCEP = async () => {
+    const cep = form.cep.replace(/\D/g,'');
+    if (cep.length !== 8) return;
+    try {
+      const resp = await fetch(`https://viacep.com.br/ws/${cep}/json/`);
+      const dados = await resp.json();
+      if (!dados.erro) {
+        setForm(prev => ({
+          ...prev,
+          rua: dados.logradouro || '',
+          bairro: dados.bairro || '',
+          cidade: dados.localidade || '',
+          estado: dados.uf || '',
+        }));
+      }
+    } catch(err) {
+      console.error('Erro ao buscar CEP', err);
+    }
+  };
+
+  const salvar = async (e) => {
+    e.preventDefault();
+    // Exemplo de envio ao backend - ajusta conforme API
+    const data = new FormData();
+    Object.entries(form).forEach(([k,v]) => {
+      if (v) data.append(k, v);
+    });
+    try {
+      await fetchComAuth('/empresa', { method: 'POST', body: data });
+      localStorage.setItem('empresaCodigoSeq', String(sequencial + 1));
+      alert('Dados salvos');
+      setSequencial(s => s+1);
+      setForm(f => ({ ...f, razaoSocial:'', nomeFantasia:'', codigo:'', cnpj:'', inscricaoEstadual:'', cep:'', rua:'', numero:'', bairro:'', cidade:'', estado:'', telefone1:'', telefone2:'', logo:null }));
+    } catch(err) {
+      alert('Falha ao salvar');
+    }
+  };
+
+  return (
+    <form onSubmit={salvar} className="space-y-4">
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+        <label className="block">
+          <span className="text-sm">Razão Social</span>
+          <input className="input" value={form.razaoSocial} onChange={handle('razaoSocial')} />
+        </label>
+        <label className="block">
+          <span className="text-sm">Nome Fantasia</span>
+          <input className="input" value={form.nomeFantasia} onChange={handle('nomeFantasia')} />
+        </label>
+        <label className="block">
+          <span className="text-sm">Código</span>
+          <input className="input bg-gray-100" value={form.codigo} readOnly />
+        </label>
+        <label className="block">
+          <span className="text-sm">CNPJ</span>
+          <input className="input" value={form.cnpj} onChange={handle('cnpj')} pattern="\d{14}" />
+        </label>
+        <label className="block">
+          <span className="text-sm">Inscrição Estadual</span>
+          <input className="input" value={form.inscricaoEstadual} onChange={handle('inscricaoEstadual')} />
+        </label>
+        <label className="block">
+          <span className="text-sm">CEP</span>
+          <input className="input" value={form.cep} onChange={handle('cep')} onBlur={buscarCEP} />
+        </label>
+        <label className="block">
+          <span className="text-sm">Rua</span>
+          <input className="input" value={form.rua} onChange={handle('rua')} />
+        </label>
+        <label className="block">
+          <span className="text-sm">Número</span>
+          <input className="input" value={form.numero} onChange={handle('numero')} />
+        </label>
+        <label className="block">
+          <span className="text-sm">Bairro</span>
+          <input className="input" value={form.bairro} onChange={handle('bairro')} />
+        </label>
+        <label className="block">
+          <span className="text-sm">Cidade</span>
+          <input className="input" value={form.cidade} onChange={handle('cidade')} />
+        </label>
+        <label className="block">
+          <span className="text-sm">Estado</span>
+          <input className="input" value={form.estado} onChange={handle('estado')} />
+        </label>
+        <label className="block">
+          <span className="text-sm">Telefone 1</span>
+          <input className="input" value={form.telefone1} onChange={handle('telefone1')} placeholder="(11) 99999-9999" />
+        </label>
+        <label className="block">
+          <span className="text-sm">Telefone 2</span>
+          <input className="input" value={form.telefone2} onChange={handle('telefone2')} placeholder="(11) 99999-9999" />
+        </label>
+        <label className="block">
+          <span className="text-sm">Logotipo</span>
+          <input type="file" accept="image/jpeg,image/png,image/svg+xml" onChange={handle('logo')} />
+        </label>
+      </div>
+      <Button type="submit">Salvar</Button>
+    </form>
+  );
+}
+
+export default DadosEmpresa;

--- a/frontend-erp/src/modules/Cadastros/index.jsx
+++ b/frontend-erp/src/modules/Cadastros/index.jsx
@@ -1,11 +1,34 @@
 import React from 'react';
+import { Routes, Route, Link, Outlet, useResolvedPath, useMatch } from 'react-router-dom';
+import DadosEmpresa from './DadosEmpresa';
+import './Cadastros.css';
 
-function Cadastros() {
+function CadastrosLayout() {
+  const resolved = useResolvedPath('');
+  const matchDados = useMatch({ path: `${resolved.pathname}`, end: true });
   return (
     <div className="p-4 bg-white rounded shadow-md">
       <h2 className="text-xl font-bold mb-4 text-blue-700">Módulo: Cadastros</h2>
-      <p>Em construção...</p>
+      <nav className="flex gap-4 mb-4 border-b pb-2">
+        <Link
+          to="." // raiz do módulo
+          className={`px-3 py-1 rounded ${matchDados ? 'bg-blue-200 text-blue-800' : 'text-blue-600 hover:bg-blue-100'}`}
+        >
+          Dados da Empresa
+        </Link>
+      </nav>
+      <Outlet />
     </div>
+  );
+}
+
+function Cadastros() {
+  return (
+    <Routes>
+      <Route path="/" element={<CadastrosLayout />}>
+        <Route index element={<DadosEmpresa />} />
+      </Route>
+    </Routes>
   );
 }
 


### PR DESCRIPTION
## Summary
- create Cadastro module layout and routing
- add Dados da Empresa form with automatic code generation and CEP lookup
- style inputs via new CSS file

## Testing
- `npm install`
- `npm run lint` *(fails: several existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_685c755d4694832dacaa22c02b06e3cb