### PR TITLE
Add client and supplier sections

### DIFF
--- a/frontend-erp/src/modules/Cadastros/Clientes.jsx
+++ b/frontend-erp/src/modules/Cadastros/Clientes.jsx
@@ -1,0 +1,40 @@
+import React, { useState } from 'react';
+import { Button } from '../Producao/components/ui/button';
+import { useNavigate } from 'react-router-dom';
+
+function Clientes() {
+  const navigate = useNavigate();
+  const [form, setForm] = useState({ nome: '', documento: '' });
+
+  const handle = campo => e => {
+    setForm(prev => ({ ...prev, [campo]: e.target.value }));
+  };
+
+  const salvar = e => {
+    e.preventDefault();
+    // Placeholder: enviar dados para API quando disponível
+    alert('Cliente salvo (exemplo).');
+    setForm({ nome: '', documento: '' });
+  };
+
+  return (
+    <form onSubmit={salvar} className="space-y-4">
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+        <label className="block">
+          <span className="text-sm">Nome</span>
+          <input className="input" value={form.nome} onChange={handle('nome')} />
+        </label>
+        <label className="block">
+          <span className="text-sm">Documento</span>
+          <input className="input" value={form.documento} onChange={handle('documento')} />
+        </label>
+      </div>
+      <div className="flex gap-2">
+        <Button type="submit">Salvar</Button>
+        <Button type="button" variant="secondary" onClick={() => navigate('lista')}>Listar Clientes</Button>
+      </div>
+    </form>
+  );
+}
+
+export default Clientes;

--- a/frontend-erp/src/modules/Cadastros/DadosEmpresa.jsx
+++ b/frontend-erp/src/modules/Cadastros/DadosEmpresa.jsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { Button } from '../Producao/components/ui/button';
 import { fetchComAuth } from '../../utils/fetchComAuth';
-import { useParams } from 'react-router-dom';
+import { useParams, useNavigate } from 'react-router-dom';
 
 function gerarCodigo(nomeFantasia, sequencial) {
   if (!nomeFantasia) return '';
@@ -13,6 +13,7 @@ function gerarCodigo(nomeFantasia, sequencial) {
 
 function DadosEmpresa() {
   const { id } = useParams();
+  const navigate = useNavigate();
   const [sequencial, setSequencial] = useState(1);
   const [form, setForm] = useState({
     razaoSocial: '',
@@ -173,7 +174,12 @@ function DadosEmpresa() {
           <input type="file" accept="image/jpeg,image/png,image/svg+xml" onChange={handle('logo')} />
         </label>
       </div>
-      <Button type="submit">Salvar</Button>
+      <div className="flex gap-2">
+        <Button type="submit">Salvar</Button>
+        <Button type="button" variant="secondary" onClick={() => navigate('lista')}>
+          Listar Empresas
+        </Button>
+      </div>
     </form>
   );
 }

--- a/frontend-erp/src/modules/Cadastros/Fornecedores.jsx
+++ b/frontend-erp/src/modules/Cadastros/Fornecedores.jsx
@@ -1,0 +1,40 @@
+import React, { useState } from 'react';
+import { Button } from '../Producao/components/ui/button';
+import { useNavigate } from 'react-router-dom';
+
+function Fornecedores() {
+  const navigate = useNavigate();
+  const [form, setForm] = useState({ nome: '', contato: '' });
+
+  const handle = campo => e => {
+    setForm(prev => ({ ...prev, [campo]: e.target.value }));
+  };
+
+  const salvar = e => {
+    e.preventDefault();
+    // Placeholder para envio futuro
+    alert('Fornecedor salvo (exemplo).');
+    setForm({ nome: '', contato: '' });
+  };
+
+  return (
+    <form onSubmit={salvar} className="space-y-4">
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+        <label className="block">
+          <span className="text-sm">Nome</span>
+          <input className="input" value={form.nome} onChange={handle('nome')} />
+        </label>
+        <label className="block">
+          <span className="text-sm">Contato</span>
+          <input className="input" value={form.contato} onChange={handle('contato')} />
+        </label>
+      </div>
+      <div className="flex gap-2">
+        <Button type="submit">Salvar</Button>
+        <Button type="button" variant="secondary" onClick={() => navigate('lista')}>Listar Fornecedores</Button>
+      </div>
+    </form>
+  );
+}
+
+export default Fornecedores;

--- a/frontend-erp/src/modules/Cadastros/ListaClientes.jsx
+++ b/frontend-erp/src/modules/Cadastros/ListaClientes.jsx
@@ -1,0 +1,24 @@
+import React from 'react';
+
+const ListaClientes = () => {
+  // Placeholder list; replace with fetch when API available
+  const clientes = [
+    { id: 1, nome: 'Cliente Exemplo 1' },
+    { id: 2, nome: 'Cliente Exemplo 2' },
+  ];
+
+  return (
+    <div className="space-y-2">
+      <h3 className="text-lg font-semibold">Clientes Cadastrados</h3>
+      <ul className="space-y-1">
+        {clientes.map((c) => (
+          <li key={c.id} className="border rounded p-2">
+            {c.nome}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+};
+
+export default ListaClientes;

--- a/frontend-erp/src/modules/Cadastros/ListaFornecedores.jsx
+++ b/frontend-erp/src/modules/Cadastros/ListaFornecedores.jsx
@@ -1,0 +1,23 @@
+import React from 'react';
+
+const ListaFornecedores = () => {
+  const fornecedores = [
+    { id: 1, nome: 'Fornecedor Exemplo 1' },
+    { id: 2, nome: 'Fornecedor Exemplo 2' },
+  ];
+
+  return (
+    <div className="space-y-2">
+      <h3 className="text-lg font-semibold">Fornecedores Cadastrados</h3>
+      <ul className="space-y-1">
+        {fornecedores.map((f) => (
+          <li key={f.id} className="border rounded p-2">
+            {f.nome}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+};
+
+export default ListaFornecedores;

--- a/frontend-erp/src/modules/Cadastros/index.jsx
+++ b/frontend-erp/src/modules/Cadastros/index.jsx
@@ -2,12 +2,17 @@ import React from 'react';
 import { Routes, Route, Link, Outlet, useResolvedPath, useMatch } from 'react-router-dom';
 import DadosEmpresa from './DadosEmpresa';
 import ListaEmpresas from './ListaEmpresas';
+import Clientes from './Clientes';
+import ListaClientes from './ListaClientes';
+import Fornecedores from './Fornecedores';
+import ListaFornecedores from './ListaFornecedores';
 import './Cadastros.css';
 
 function CadastrosLayout() {
   const resolved = useResolvedPath('');
   const matchDados = useMatch({ path: `${resolved.pathname}`, end: true });
-  const matchLista = useMatch(`${resolved.pathname}/lista`);
+  const matchClientes = useMatch(`${resolved.pathname}/clientes`);
+  const matchFornecedores = useMatch(`${resolved.pathname}/fornecedores`);
   return (
     <div className="p-4 bg-white rounded shadow-md">
       <h2 className="text-xl font-bold mb-4 text-blue-700">Módulo: Cadastros</h2>
@@ -19,10 +24,16 @@ function CadastrosLayout() {
           Dados da Empresa
         </Link>
         <Link
-          to="lista"
-          className={`px-3 py-1 rounded ${matchLista ? 'bg-blue-200 text-blue-800' : 'text-blue-600 hover:bg-blue-100'}`}
+          to="clientes"
+          className={`px-3 py-1 rounded ${matchClientes ? 'bg-blue-200 text-blue-800' : 'text-blue-600 hover:bg-blue-100'}`}
         >
-          Lista de Empresas
+          Clientes
+        </Link>
+        <Link
+          to="fornecedores"
+          className={`px-3 py-1 rounded ${matchFornecedores ? 'bg-blue-200 text-blue-800' : 'text-blue-600 hover:bg-blue-100'}`}
+        >
+          Fornecedores
         </Link>
       </nav>
       <Outlet />
@@ -37,6 +48,10 @@ function Cadastros() {
         <Route index element={<DadosEmpresa />} />
         <Route path="lista" element={<ListaEmpresas />} />
         <Route path="editar/:id" element={<DadosEmpresa />} />
+        <Route path="clientes" element={<Clientes />} />
+        <Route path="clientes/lista" element={<ListaClientes />} />
+        <Route path="fornecedores" element={<Fornecedores />} />
+        <Route path="fornecedores/lista" element={<ListaFornecedores />} />
       </Route>
     </Routes>
   );


### PR DESCRIPTION
## Summary
- add forms and listing pages for clients and suppliers
- put list of companies behind a button in DadosEmpresa
- update Cadastros navigation tabs and routes

## Testing
- `npm run lint` *(fails: 55 errors in existing files)*

------
https://chatgpt.com/codex/tasks/task_e_685c7b371450832db55dff40e751e3f4