### PR TITLE
Fix jsPDF import in RelatorioOcorrencias

### DIFF
--- a/frontend-erp/src/modules/Producao/components/RelatorioOcorrencias.jsx
+++ b/frontend-erp/src/modules/Producao/components/RelatorioOcorrencias.jsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from "react";
 import { fetchComAuth } from "../../../utils/fetchComAuth";
-import jsPDF from "jspdf";
+import { jsPDF } from "jspdf";
 import html2canvas from "html2canvas";
 
 const RelatorioOcorrencias = () => {


### PR DESCRIPTION
## Summary
- fix import for jsPDF to align with jsPDF package documentation

## Testing
- `npm run lint` *(fails: numerous unrelated lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_685d409291dc832db6f07fabaed4f5d8