### PR TITLE
Fix duplicate prefix in occurrence batch name

### DIFF
--- a/frontend-erp/src/modules/Producao/components/PacoteOcorrencia.jsx
+++ b/frontend-erp/src/modules/Producao/components/PacoteOcorrencia.jsx
@@ -82,7 +82,7 @@ const PacoteOcorrencia = () => {
       return;
     }
     alert(`OC ${String(resp.oc_numero).padStart(8, "0")} gerada`);
-    const nomeLoteFinal = `Lote_${loteLocal.lote}_OC${resp.oc_numero}`;
+    const nomeLoteFinal = `${loteLocal.lote}_OC${resp.oc_numero}`;
     const lotesProd = JSON.parse(localStorage.getItem("lotesProducao") || "[]");
     lotesProd.push({
       nome: nomeLoteFinal,

--- a/producao/backend/src/api.py
+++ b/producao/backend/src/api.py
@@ -522,7 +522,10 @@ async def gerar_lote_ocorrencia(request: Request):
             }
 
     numero_oc = proximo_oc_numero()
-    pasta_saida = SAIDA_DIR / f"Lote_{lote}_OC{numero_oc}"
+    lote_nome = str(lote)
+    if not lote_nome.startswith("Lote_"):
+        lote_nome = f"Lote_{lote_nome}"
+    pasta_saida = SAIDA_DIR / f"{lote_nome}_OC{numero_oc}"
     os.makedirs(pasta_saida, exist_ok=True)
 
     todas = []
@@ -557,7 +560,7 @@ async def gerar_lote_ocorrencia(request: Request):
             "Comment": obs,
         })
 
-    caminho_dxt_final = pasta_saida / f"Lote_{lote}_OC{numero_oc}.dxt"
+    caminho_dxt_final = pasta_saida / f"{lote_nome}_OC{numero_oc}.dxt"
     with open(caminho_dxt_final, "w", encoding="utf-8") as f:
         f.write("<?xml version=\"1.0\"?>\n<ListInformation>\n   <ApplicationData>\n")
         f.write("     <Name />\n     <Version>1.0</Version>\n")


### PR DESCRIPTION
## Summary
- avoid adding `Lote_` twice when creating occurrence batch folders on the backend
- stop prefixing `Lote_` on the frontend when storing the generated occurrence batch name

## Testing
- `python -m py_compile producao/backend/src/api.py`
- `npm run lint` *(fails: several lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_685d82d811e0832d98a7f620fb3520f7