### PR TITLE
Add default admin user on startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,12 @@ RADHA_ERP_ROOT=/opt/radha/radha-erp ./update_github.sh
 See `rodar_ambientes.txt` for the commands used to launch each backend and the frontend. You can adapt these into a systemd unit like the example `radha-erp.service` provided in the repository.
 The `start_services.sh` script offers a simple way to run every component locally.
 
+### Default credentials
+When the application is started for the first time and the user database is empty,
+it will create a default administrator account. You can override the username and
+password using the `RADHA_ADMIN_USER` and `RADHA_ADMIN_PASS` environment
+variables. The default values are `admin` / `admin`.
+
 
 ## Troubleshooting
 

--- a/marketing-digital-ia/backend/database.py
+++ b/marketing-digital-ia/backend/database.py
@@ -28,6 +28,23 @@ def init_db():
         )"""
     )
     conn.commit()
+
+    # Create a default admin user on first run
+    exists = cur.execute("SELECT COUNT(*) FROM users").fetchone()[0]
+    if exists == 0:
+        cur.execute(
+            "INSERT INTO users (username, password, email, nome, cargo, permissoes)"
+            " VALUES (?, ?, ?, ?, ?, ?)",
+            (
+                os.getenv("RADHA_ADMIN_USER", "admin"),
+                os.getenv("RADHA_ADMIN_PASS", "admin"),
+                "admin@example.com",
+                "Administrador",
+                "admin",
+                "[\"chat\", \"campanhas\", \"publicacoes\", \"publico\", \"marketing-ia\", \"producao\", \"cadastros\"]",
+            ),
+        )
+        conn.commit()
     conn.close()
 
 


### PR DESCRIPTION
## Summary
- seed admin user when Marketing IA backend database has no users
- document default credentials

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `npm --prefix frontend-erp run lint` *(fails: Cannot find package '@eslint/js')*
- `npm --prefix marketing-digital-ia/frontend run build` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d8df163f8832d9b40449aca36a320