### PR TITLE
Fix Cadastros module import

### DIFF
--- a/frontend-erp/src/modules/Cadastros/index.jsx
+++ b/frontend-erp/src/modules/Cadastros/index.jsx
@@ -5,6 +5,7 @@ import ListaEmpresas from './ListaEmpresas';
 import Clientes from './Clientes';
 import ListaClientes from './ListaClientes';
 import Fornecedores from './Fornecedores';
+import ListaFornecedores from './ListaFornecedores';
 import Usuarios from './Usuarios';
 import ListaUsuarios from './ListaUsuarios';
 import './Cadastros.css';


### PR DESCRIPTION
## Summary
- import `ListaFornecedores` in the Cadastros module so the route renders correctly

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js' / lint errors)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_685d921e4200832d90d3d1e17c02e4d4