### PR TITLE
Fix /usuarios endpoint 404

### DIFF
--- a/backend-gateway/main.py
+++ b/backend-gateway/main.py
@@ -207,6 +207,12 @@ async def validate_token(request: Request):
 # Cadastros - Usuarios
 # -------------------------
 
+@app.api_route("/usuarios", methods=["GET", "POST", "PUT", "DELETE"])
+async def usuarios_proxy_root(request: Request):
+    """Repasse para o backend de usuarios na raiz do endpoint."""
+    return await usuarios_proxy("", request)
+
+
 @app.api_route("/usuarios/{path:path}", methods=["GET", "POST", "PUT", "DELETE"])
 async def usuarios_proxy(path: str = "", request: Request = None):
     async with httpx.AsyncClient() as client:


### PR DESCRIPTION
## Summary
- add explicit route to handle `/usuarios` without a trailing slash

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_685d9c90230c832d8b25eb4102f4c21a