### PR TITLE
Fix users route path

### DIFF
--- a/marketing-digital-ia/backend/main.py
+++ b/marketing-digital-ia/backend/main.py
@@ -17,7 +17,11 @@ app.include_router(publicacao.router, prefix="/nova-publicacao")
 app.include_router(publicos.router, prefix="/publicos")
 app.include_router(conhecimento.router, prefix="/conhecimento")
 app.include_router(auth.router, prefix="/auth")
-app.include_router(usuarios.router, prefix="/usuarios")
+# A rota de usuarios ja define um prefixo, portanto nao precisamos
+# adicionar outro aqui. Mantendo apenas o include simples evita que a
+# rota final fique "/usuarios/usuarios" e resolvemos erros 404 ao
+# acessar via gateway.
+app.include_router(usuarios.router)
 
 
 @app.get("/")


### PR DESCRIPTION
## Summary
- correct users router import to avoid double prefix causing 404 errors

## Testing
- `npm test` *(fails: no package.json)*
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_685da007e0b4832dbfad3ccde39f4aef