### PR TITLE
Add user editing and cleanup lot listing

### DIFF
--- a/frontend-erp/src/modules/Cadastros/ListaUsuarios.jsx
+++ b/frontend-erp/src/modules/Cadastros/ListaUsuarios.jsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from 'react';
+import { Link } from 'react-router-dom';
 import { fetchComAuth } from '../../utils/fetchComAuth';
 
 const ListaUsuarios = () => {
@@ -9,13 +10,22 @@ const ListaUsuarios = () => {
   };
   useEffect(() => { carregar(); }, []);
 
+  const excluir = async id => {
+    await fetchComAuth(`/usuarios/${id}`, { method: 'DELETE' }).catch(() => {});
+    carregar();
+  };
+
   return (
     <div className="space-y-2">
       <h3 className="text-lg font-semibold">Usuários</h3>
       <ul className="space-y-1">
         {usuarios.map(u => (
-          <li key={u.id} className="border rounded p-2 flex justify-between">
+          <li key={u.id} className="border rounded p-2 flex justify-between items-center">
             <span>{u.username} - {u.cargo}</span>
+            <div className="space-x-2">
+              <Link className="text-blue-600 hover:underline" to={`../editar/${u.id}`}>Editar</Link>
+              <button className="text-red-600 hover:underline" onClick={() => excluir(u.id)}>Excluir</button>
+            </div>
           </li>
         ))}
       </ul>

--- a/frontend-erp/src/modules/Cadastros/index.jsx
+++ b/frontend-erp/src/modules/Cadastros/index.jsx
@@ -65,6 +65,7 @@ function Cadastros() {
         <Route path="fornecedores/editar/:id" element={<Fornecedores />} />
         <Route path="usuarios" element={<Usuarios />} />
         <Route path="usuarios/lista" element={<ListaUsuarios />} />
+        <Route path="usuarios/editar/:id" element={<Usuarios />} />
       </Route>
     </Routes>
   );

--- a/producao/backend/src/api.py
+++ b/producao/backend/src/api.py
@@ -229,12 +229,19 @@ async def listar_lotes():
     try:
         with get_db_connection() as conn:
             rows = conn.execute(
-                "SELECT pasta FROM lotes ORDER BY id"
+                "SELECT id, pasta FROM lotes ORDER BY id"
             ).fetchall()
-            lotes = [row["pasta"] for row in rows]
+            lotes_validos = []
+            for row in rows:
+                pasta = Path(row["pasta"])
+                if pasta.is_dir():
+                    lotes_validos.append(str(pasta))
+                else:
+                    conn.execute("DELETE FROM lotes WHERE id=?", (row["id"],))
+            conn.commit()
     except Exception:
-        lotes = []
-    return {"lotes": lotes}
+        lotes_validos = []
+    return {"lotes": lotes_validos}
 
 
 @app.get("/nestings")


### PR DESCRIPTION
## Summary
- add edit/delete buttons to user listing
- allow user editing and adapt save logic
- register route for editing users
- filter missing folders from `/listar-lotes`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` in marketing-digital-ia frontend *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_685da299cc98832db351f3a9e4e1c2ae