### PR TITLE
Improve ERP permissions and empresa

### DIFF
--- a/frontend-erp/src/App.jsx
+++ b/frontend-erp/src/App.jsx
@@ -15,6 +15,7 @@ import Producao from "./modules/Producao";
 import Cadastros from "./modules/Cadastros";
 import Login from "./pages/Login";
 import { fetchComAuth } from "./utils/fetchComAuth";
+import { UserContext } from "./UserContext";
 
 // Componente de Layout: A "moldura" do ERP para um usuário logado
 function Layout({ usuario, onLogout }) {
@@ -27,7 +28,8 @@ function Layout({ usuario, onLogout }) {
   return (
     <div className="min-h-screen flex">
       <aside className="bg-blue-900 text-white p-4 flex flex-col w-[20%] min-w-[200px]">
-        <h1 className="text-2xl font-bold mb-6">Radha ERP</h1>
+        <h1 className="text-2xl font-bold">Radha ERP</h1>
+        <p className="text-sm mb-4">Usuário: {usuario?.nome}</p>
         <nav className="flex flex-col space-y-2 flex-grow">
           {possuiPermissao("cadastros") && (
             <Link
@@ -62,7 +64,9 @@ function Layout({ usuario, onLogout }) {
         </button>
       </aside>
       <main className="flex-grow p-4 bg-gray-100">
-        <Outlet />
+        <UserContext.Provider value={usuario}>
+          <Outlet />
+        </UserContext.Provider>
       </main>
     </div>
   );

--- a/frontend-erp/src/UserContext.jsx
+++ b/frontend-erp/src/UserContext.jsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+export const UserContext = React.createContext(null);
+
+export function useUsuario() {
+  return React.useContext(UserContext);
+}

--- a/frontend-erp/src/modules/Cadastros/Clientes.jsx
+++ b/frontend-erp/src/modules/Cadastros/Clientes.jsx
@@ -264,6 +264,9 @@ function Clientes() {
       </div>
       <div className="flex gap-2">
         <Button type="submit">Salvar</Button>
+        <Button type="button" variant="secondary" onClick={() => navigate(-1)}>
+          Cancelar
+        </Button>
         <Button type="button" variant="secondary" onClick={() => navigate('lista')}>
           Listar Clientes
         </Button>

--- a/frontend-erp/src/modules/Cadastros/Fornecedores.jsx
+++ b/frontend-erp/src/modules/Cadastros/Fornecedores.jsx
@@ -49,6 +49,9 @@ function Fornecedores() {
       </div>
       <div className="flex gap-2">
         <Button type="submit">Salvar</Button>
+        <Button type="button" variant="secondary" onClick={() => navigate(-1)}>
+          Cancelar
+        </Button>
         <Button type="button" variant="secondary" onClick={() => navigate('lista')}>Listar Fornecedores</Button>
       </div>
     </form>

--- a/frontend-erp/src/modules/Cadastros/ListaEmpresas.jsx
+++ b/frontend-erp/src/modules/Cadastros/ListaEmpresas.jsx
@@ -2,20 +2,19 @@ import React, { useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
 
 const ListaEmpresas = () => {
-  const [empresas, setEmpresas] = useState([]);
+  const [empresa, setEmpresa] = useState(null);
 
   const carregar = () => {
-    const lista = JSON.parse(localStorage.getItem('empresas') || '[]');
-    setEmpresas(lista);
+    const obj = JSON.parse(localStorage.getItem('empresa') || 'null');
+    setEmpresa(obj);
   };
 
   useEffect(() => {
     carregar();
   }, []);
 
-  const excluir = id => {
-    const lista = JSON.parse(localStorage.getItem('empresas') || '[]').filter(e => e.id !== id);
-    localStorage.setItem('empresas', JSON.stringify(lista));
+  const excluir = () => {
+    localStorage.removeItem('empresa');
     carregar();
   };
 
@@ -23,20 +22,17 @@ const ListaEmpresas = () => {
     <div className="space-y-2">
       <h3 className="text-lg font-semibold">Empresas Cadastradas</h3>
       <ul className="space-y-1">
-        {empresas.map(e => (
-          <li key={e.id} className="flex justify-between items-center border rounded p-2">
-            <span>{e.codigo} - {e.nomeFantasia || e.nome_fantasia}</span>
+        {empresa && (
+          <li className="flex justify-between items-center border rounded p-2">
+            <span>{empresa.nomeFantasia || empresa.nome_fantasia}</span>
             <div className="space-x-2">
-              <Link
-                className="text-blue-600 hover:underline"
-                to={`/cadastros/editar/${e.id}`}
-              >
+              <Link className="text-blue-600 hover:underline" to="/cadastros">
                 Editar
               </Link>
-              <button className="text-red-600 hover:underline" onClick={() => excluir(e.id)}>Excluir</button>
+              <button className="text-red-600 hover:underline" onClick={excluir}>Excluir</button>
             </div>
           </li>
-        ))}
+        )}
       </ul>
     </div>
   );

--- a/frontend-erp/src/modules/Cadastros/Usuarios.jsx
+++ b/frontend-erp/src/modules/Cadastros/Usuarios.jsx
@@ -55,6 +55,15 @@ function Usuarios() {
         : prev.permissoes.filter(p => p !== perm)
     }));
   };
+  const toggleGrupo = (grupo, checked) => {
+    const permissoes = PERMISSOES_DISPONIVEIS[grupo];
+    setForm(prev => ({
+      ...prev,
+      permissoes: checked
+        ? Array.from(new Set([...prev.permissoes, ...permissoes]))
+        : prev.permissoes.filter(p => !permissoes.includes(p))
+    }));
+  };
 
   const salvar = async e => {
     e.preventDefault();
@@ -80,29 +89,43 @@ function Usuarios() {
         <label className="block md:col-span-2">
           <span className="text-sm">Permissões</span>
           <div className="border rounded p-2 max-h-40 overflow-y-auto space-y-2">
-            {Object.entries(PERMISSOES_DISPONIVEIS).map(([grupo, permissoes]) => (
-              <fieldset key={grupo} className="border-b last:border-b-0 pb-1">
-                <legend className="font-medium">{grupo}</legend>
-                <div className="flex flex-col pl-2">
-                  {permissoes.map(p => (
-                    <label key={p} className="inline-flex items-center gap-1">
-                      <input
-                        type="checkbox"
-                        value={p}
-                        checked={form.permissoes.includes(p)}
-                        onChange={e => togglePermissao(p, e.target.checked)}
-                      />
-                      <span>{p}</span>
-                    </label>
-                  ))}
-                </div>
-              </fieldset>
-            ))}
+            {Object.entries(PERMISSOES_DISPONIVEIS).map(([grupo, permissoes]) => {
+              const [pai, ...filhos] = permissoes;
+              const todosMarcados = permissoes.every(p => form.permissoes.includes(p));
+              return (
+                <fieldset key={grupo} className="border-b last:border-b-0 pb-1">
+                  <label className="inline-flex items-center gap-1 font-medium">
+                    <input
+                      type="checkbox"
+                      checked={todosMarcados}
+                      onChange={e => toggleGrupo(grupo, e.target.checked)}
+                    />
+                    {grupo}
+                  </label>
+                  <div className="flex flex-col pl-4">
+                    {filhos.map(p => (
+                      <label key={p} className="inline-flex items-center gap-1">
+                        <input
+                          type="checkbox"
+                          value={p}
+                          checked={form.permissoes.includes(p)}
+                          onChange={e => togglePermissao(p, e.target.checked)}
+                        />
+                        <span>{p}</span>
+                      </label>
+                    ))}
+                  </div>
+                </fieldset>
+              );
+            })}
           </div>
         </label>
       </div>
       <div className="flex gap-2">
         <Button type="submit">Salvar</Button>
+        <Button type="button" variant="secondary" onClick={() => navigate(-1)}>
+          Cancelar
+        </Button>
         <Button type="button" variant="secondary" onClick={() => navigate('lista')}>Listar Usuários</Button>
       </div>
     </form>

--- a/frontend-erp/src/modules/Cadastros/index.jsx
+++ b/frontend-erp/src/modules/Cadastros/index.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Routes, Route, Link, Outlet, useResolvedPath, useMatch } from 'react-router-dom';
+import { useUsuario } from '../../UserContext';
 import DadosEmpresa from './DadosEmpresa';
 import ListaEmpresas from './ListaEmpresas';
 import Clientes from './Clientes';
@@ -16,34 +17,44 @@ function CadastrosLayout() {
   const matchClientes = useMatch(`${resolved.pathname}/clientes`);
   const matchFornecedores = useMatch(`${resolved.pathname}/fornecedores`);
   const matchUsuarios = useMatch(`${resolved.pathname}/usuarios`);
+  const usuario = useUsuario();
+  const possuiPermissao = p => usuario?.permissoes?.includes(p);
   return (
     <div className="p-4 bg-white rounded shadow-md">
       <h2 className="text-xl font-bold mb-4 text-blue-700">Módulo: Cadastros</h2>
       <nav className="flex gap-4 mb-4 border-b pb-2">
-        <Link
-          to="." // raiz do módulo
-          className={`px-3 py-1 rounded ${matchDados ? 'bg-blue-200 text-blue-800' : 'text-blue-600 hover:bg-blue-100'}`}
-        >
-          Dados da Empresa
-        </Link>
-        <Link
-          to="clientes"
-          className={`px-3 py-1 rounded ${matchClientes ? 'bg-blue-200 text-blue-800' : 'text-blue-600 hover:bg-blue-100'}`}
-        >
-          Clientes
-        </Link>
-        <Link
-          to="fornecedores"
-          className={`px-3 py-1 rounded ${matchFornecedores ? 'bg-blue-200 text-blue-800' : 'text-blue-600 hover:bg-blue-100'}`}
-        >
-          Fornecedores
-        </Link>
-        <Link
-          to="usuarios"
-          className={`px-3 py-1 rounded ${matchUsuarios ? 'bg-blue-200 text-blue-800' : 'text-blue-600 hover:bg-blue-100'}`}
-        >
-          Usuários
-        </Link>
+        {possuiPermissao('cadastros/dados-empresa') && (
+          <Link
+            to="." // raiz do módulo
+            className={`px-3 py-1 rounded ${matchDados ? 'bg-blue-200 text-blue-800' : 'text-blue-600 hover:bg-blue-100'}`}
+          >
+            Dados da Empresa
+          </Link>
+        )}
+        {possuiPermissao('cadastros/clientes') && (
+          <Link
+            to="clientes"
+            className={`px-3 py-1 rounded ${matchClientes ? 'bg-blue-200 text-blue-800' : 'text-blue-600 hover:bg-blue-100'}`}
+          >
+            Clientes
+          </Link>
+        )}
+        {possuiPermissao('cadastros/fornecedores') && (
+          <Link
+            to="fornecedores"
+            className={`px-3 py-1 rounded ${matchFornecedores ? 'bg-blue-200 text-blue-800' : 'text-blue-600 hover:bg-blue-100'}`}
+          >
+            Fornecedores
+          </Link>
+        )}
+        {possuiPermissao('cadastros/usuarios') && (
+          <Link
+            to="usuarios"
+            className={`px-3 py-1 rounded ${matchUsuarios ? 'bg-blue-200 text-blue-800' : 'text-blue-600 hover:bg-blue-100'}`}
+          >
+            Usuários
+          </Link>
+        )}
       </nav>
       <Outlet />
     </div>

--- a/frontend-erp/src/modules/MarketingDigitalIA/index.jsx
+++ b/frontend-erp/src/modules/MarketingDigitalIA/index.jsx
@@ -1,6 +1,7 @@
 // radha-erp/frontend-erp/src/modules/MarketingDigitalIA/index.jsx
 import React from 'react';
 import { Routes, Route, Link, Outlet, useResolvedPath, useMatch } from 'react-router-dom';
+import { useUsuario } from '../../UserContext';
 import Chat from './pages/Chat';
 import NovaCampanha from './pages/NovaCampanha';
 import NovaPublicacao from './pages/NovaPublicacao';
@@ -14,35 +15,45 @@ function MarketingDigitalIALayout() {
   const matchCampanha = useMatch(`${resolved.pathname}/nova-campanha`);
   const matchPublicacao = useMatch(`${resolved.pathname}/nova-publicacao`);
   const matchPublicos = useMatch(`${resolved.pathname}/publicos-alvo`);
+  const usuario = useUsuario();
+  const possuiPermissao = p => usuario?.permissoes?.includes(p);
 
   return (
     <div className="p-4 bg-white rounded shadow-md">
       <h2 className="text-xl font-bold mb-4 text-blue-700">Módulo: Marketing Digital IA</h2>
       <nav className="flex gap-4 mb-4 border-b pb-2">
-        <Link
-          to="." // Relativo ao path do módulo (MarketingDigitalIA)
-          className={`px-3 py-1 rounded ${matchChat ? 'bg-blue-200 text-blue-800' : 'text-blue-600 hover:bg-blue-100'}`}
-        >
-          Assistente Sara
-        </Link>
-        <Link
-          to="nova-campanha" // Relativo ao path do módulo
-          className={`px-3 py-1 rounded ${matchCampanha ? 'bg-blue-200 text-blue-800' : 'text-blue-600 hover:bg-blue-100'}`}
-        >
-          Nova Campanha
-        </Link>
-        <Link
-          to="nova-publicacao" // Relativo ao path do módulo
-          className={`px-3 py-1 rounded ${matchPublicacao ? 'bg-blue-200 text-blue-800' : 'text-blue-600 hover:bg-blue-100'}`}
-        >
-          Nova Publicação
-        </Link>
-        <Link
-          to="publicos-alvo" // Relativo ao path do módulo
-          className={`px-3 py-1 rounded ${matchPublicos ? 'bg-blue-200 text-blue-800' : 'text-blue-600 hover:bg-blue-100'}`}
-        >
-          Públicos Alvo
-        </Link>
+        {possuiPermissao('marketing-ia/chat') && (
+          <Link
+            to="." // Relativo ao path do módulo (MarketingDigitalIA)
+            className={`px-3 py-1 rounded ${matchChat ? 'bg-blue-200 text-blue-800' : 'text-blue-600 hover:bg-blue-100'}`}
+          >
+            Assistente Sara
+          </Link>
+        )}
+        {possuiPermissao('marketing-ia/nova-campanha') && (
+          <Link
+            to="nova-campanha" // Relativo ao path do módulo
+            className={`px-3 py-1 rounded ${matchCampanha ? 'bg-blue-200 text-blue-800' : 'text-blue-600 hover:bg-blue-100'}`}
+          >
+            Nova Campanha
+          </Link>
+        )}
+        {possuiPermissao('marketing-ia/nova-publicacao') && (
+          <Link
+            to="nova-publicacao" // Relativo ao path do módulo
+            className={`px-3 py-1 rounded ${matchPublicacao ? 'bg-blue-200 text-blue-800' : 'text-blue-600 hover:bg-blue-100'}`}
+          >
+            Nova Publicação
+          </Link>
+        )}
+        {possuiPermissao('marketing-ia/publicos-alvo') && (
+          <Link
+            to="publicos-alvo" // Relativo ao path do módulo
+            className={`px-3 py-1 rounded ${matchPublicos ? 'bg-blue-200 text-blue-800' : 'text-blue-600 hover:bg-blue-100'}`}
+          >
+            Públicos Alvo
+          </Link>
+        )}
       </nav>
       <Outlet /> {/* Renderiza as rotas aninhadas aqui */}
     </div>

--- a/frontend-erp/src/modules/Producao/index.jsx
+++ b/frontend-erp/src/modules/Producao/index.jsx
@@ -1,6 +1,7 @@
 // radha-erp/frontend-erp/src/modules/Producao/index.jsx
 import React from 'react';
 import { Routes, Route, Link, Outlet, useResolvedPath, useMatch } from 'react-router-dom';
+import { useUsuario } from '../../UserContext';
 // Importa os componentes renomeados do AppProducao.jsx
 import { HomeProducao, LoteProducao, EditarPecaProducao, Pacote, Apontamento, ApontamentoVolume, EditarFerragem, Nesting, ConfigMaquina, LotesOcorrencia, CadastroMotivos, RelatorioOcorrencias, EditarLoteOcorrencia, PacoteOcorrencia } from './AppProducao';
 import CadastroChapas from './components/CadastroChapas';
@@ -16,53 +17,69 @@ function ProducaoLayout() {
   const matchChapas = useMatch({ path: `${resolved.pathname}/chapas`, end: true });
   const matchOcorr = useMatch({ path: `${resolved.pathname}/ocorrencias`, end: false });
   const matchRelatorio = useMatch({ path: `${resolved.pathname}/relatorios/ocorrencias`, end: false });
+  const usuario = useUsuario();
+  const possuiPermissao = p => usuario?.permissoes?.includes(p);
 
   return (
     <div className="p-4 bg-white rounded shadow-md">
       <h2 className="text-xl font-bold mb-4 text-blue-700">Módulo: Produção</h2>
       <nav className="flex gap-4 mb-4 border-b pb-2">
-        <Link
-          to="." // Relativo ao path do módulo (Producao)
-          className={`px-3 py-1 rounded ${matchHome ? 'bg-blue-200 text-blue-800' : 'text-blue-600 hover:bg-blue-100'}`}
-        >
-          Lotes Produção
-        </Link>
-        <Link
-          to="apontamento"
-          className={`px-3 py-1 rounded ${matchApontamento ? 'bg-blue-200 text-blue-800' : 'text-blue-600 hover:bg-blue-100'}`}
-        >
-          Apontamento
-        </Link>
-        <Link
-          to="apontamento-volume"
-          className={`px-3 py-1 rounded ${matchVolume ? 'bg-blue-200 text-blue-800' : 'text-blue-600 hover:bg-blue-100'}`}
-        >
-          Apontamento Volume
-        </Link>
-        <Link
-          to="nesting"
-          className={`px-3 py-1 rounded ${matchNesting ? 'bg-blue-200 text-blue-800' : 'text-blue-600 hover:bg-blue-100'}`}
-        >
-          Nesting
-        </Link>
-        <Link
-          to="chapas"
-          className={`px-3 py-1 rounded ${matchChapas ? 'bg-blue-200 text-blue-800' : 'text-blue-600 hover:bg-blue-100'}`}
-        >
-          Chapas
-        </Link>
-        <Link
-          to="ocorrencias"
-          className={`px-3 py-1 rounded ${matchOcorr ? 'bg-blue-200 text-blue-800' : 'text-blue-600 hover:bg-blue-100'}`}
-        >
-          Lotes Ocorrência
-        </Link>
-        <Link
-          to="relatorios/ocorrencias"
-          className={`px-3 py-1 rounded ${matchRelatorio ? 'bg-blue-200 text-blue-800' : 'text-blue-600 hover:bg-blue-100'}`}
-        >
-          Relatórios
-        </Link>
+        {possuiPermissao('producao') && (
+          <Link
+            to="." // Relativo ao path do módulo (Producao)
+            className={`px-3 py-1 rounded ${matchHome ? 'bg-blue-200 text-blue-800' : 'text-blue-600 hover:bg-blue-100'}`}
+          >
+            Lotes Produção
+          </Link>
+        )}
+        {possuiPermissao('producao/apontamento') && (
+          <Link
+            to="apontamento"
+            className={`px-3 py-1 rounded ${matchApontamento ? 'bg-blue-200 text-blue-800' : 'text-blue-600 hover:bg-blue-100'}`}
+          >
+            Apontamento
+          </Link>
+        )}
+        {possuiPermissao('producao/apontamento-volume') && (
+          <Link
+            to="apontamento-volume"
+            className={`px-3 py-1 rounded ${matchVolume ? 'bg-blue-200 text-blue-800' : 'text-blue-600 hover:bg-blue-100'}`}
+          >
+            Apontamento Volume
+          </Link>
+        )}
+        {possuiPermissao('producao/nesting') && (
+          <Link
+            to="nesting"
+            className={`px-3 py-1 rounded ${matchNesting ? 'bg-blue-200 text-blue-800' : 'text-blue-600 hover:bg-blue-100'}`}
+          >
+            Nesting
+          </Link>
+        )}
+        {possuiPermissao('producao/chapas') && (
+          <Link
+            to="chapas"
+            className={`px-3 py-1 rounded ${matchChapas ? 'bg-blue-200 text-blue-800' : 'text-blue-600 hover:bg-blue-100'}`}
+          >
+            Chapas
+          </Link>
+        )}
+        {possuiPermissao('producao/ocorrencias') && (
+          <Link
+            to="ocorrencias"
+            className={`px-3 py-1 rounded ${matchOcorr ? 'bg-blue-200 text-blue-800' : 'text-blue-600 hover:bg-blue-100'}`}
+          >
+            Lotes Ocorrência
+          </Link>
+        )}
+        {possuiPermissao('producao/relatorios/ocorrencias') && (
+          <Link
+            to="relatorios/ocorrencias"
+            className={`px-3 py-1 rounded ${matchRelatorio ? 'bg-blue-200 text-blue-800' : 'text-blue-600 hover:bg-blue-100'}`}
+          >
+            Relatórios
+          </Link>
+        )}
         {/* Adicionar mais links de navegação interna do módulo, se necessário */}
       </nav>
       <Outlet /> {/* Renderiza as rotas aninhadas aqui */}


### PR DESCRIPTION
## Summary
- show logged user name in sidebar and share context
- filter navigation by user permissions
- persist only one company record
- add cancel buttons to forms
- implement tree-like permission selection

## Testing
- `npm run lint` *(fails: no-mixed-spaces-and-tabs and other errors)*

------
https://chatgpt.com/codex/tasks/task_e_685db10bfeb8832d951dbdee9dba4082