### PR TITLE
Fix new cadastro route path

### DIFF
--- a/frontend-erp/src/modules/Cadastros/CadastroMenu.jsx
+++ b/frontend-erp/src/modules/Cadastros/CadastroMenu.jsx
@@ -2,13 +2,13 @@ import React, { useState } from 'react';
 import { Button } from '../Producao/components/ui/button';
 import { Link } from 'react-router-dom';
 
-function CadastroMenu({ basePath, ListaComponente }) {
+function CadastroMenu({ ListaComponente }) {
   const [mostrarLista, setMostrarLista] = useState(false);
 
   return (
     <div className="space-y-2">
       <Button asChild>
-        <Link to={`${basePath}/novo`}>Novo Cadastro</Link>
+        <Link to="novo">Novo Cadastro</Link>
       </Button>
       <Button
         type="button"

--- a/frontend-erp/src/modules/Cadastros/index.jsx
+++ b/frontend-erp/src/modules/Cadastros/index.jsx
@@ -69,26 +69,17 @@ function Cadastros() {
         <Route index element={<DadosEmpresa />} />
         <Route path="lista" element={<ListaEmpresas />} />
         <Route path="editar/:id" element={<DadosEmpresa />} />
-        <Route
-          path="clientes"
-          element={<CadastroMenu basePath="clientes" ListaComponente={ListaClientes} />}
-        />
+        <Route path="clientes" element={<CadastroMenu ListaComponente={ListaClientes} />} />
         <Route path="clientes/novo" element={<Clientes />} />
         <Route path="clientes/lista" element={<ListaClientes />} />
         <Route path="clientes/editar/:id" element={<Clientes />} />
 
-        <Route
-          path="fornecedores"
-          element={<CadastroMenu basePath="fornecedores" ListaComponente={ListaFornecedores} />}
-        />
+        <Route path="fornecedores" element={<CadastroMenu ListaComponente={ListaFornecedores} />} />
         <Route path="fornecedores/novo" element={<Fornecedores />} />
         <Route path="fornecedores/lista" element={<ListaFornecedores />} />
         <Route path="fornecedores/editar/:id" element={<Fornecedores />} />
 
-        <Route
-          path="usuarios"
-          element={<CadastroMenu basePath="usuarios" ListaComponente={ListaUsuarios} />}
-        />
+        <Route path="usuarios" element={<CadastroMenu ListaComponente={ListaUsuarios} />} />
         <Route path="usuarios/novo" element={<Usuarios />} />
         <Route path="usuarios/lista" element={<ListaUsuarios />} />
         <Route path="usuarios/editar/:id" element={<Usuarios />} />


### PR DESCRIPTION
## Summary
- fix path for new cadastro
- remove unused basePath prop

## Testing
- `npm run lint` *(fails: pai is assigned a value but never used, etc)*

------
https://chatgpt.com/codex/tasks/task_e_685dbe1cc488832da0f3e9a309d0cff7