### PR TITLE
Improve form navigation

### DIFF
--- a/frontend-erp/src/modules/Cadastros/Clientes.jsx
+++ b/frontend-erp/src/modules/Cadastros/Clientes.jsx
@@ -64,6 +64,7 @@ function Clientes() {
     email: '',
   };
   const [form, setForm] = useState(initialForm);
+  const [dirty, setDirty] = useState(false);
 
   useEffect(() => {
     const seq = parseInt(localStorage.getItem('clienteCodigoSeq') || '1', 10);
@@ -96,6 +97,7 @@ function Clientes() {
       value = formatCEP(value);
     }
     setForm(prev => ({ ...prev, [campo]: value }));
+    setDirty(true);
   };
 
   const buscarCEP = async () => {
@@ -118,8 +120,7 @@ function Clientes() {
     }
   };
 
-  const salvar = e => {
-    e.preventDefault();
+  const salvar = () => {
     const lista = JSON.parse(localStorage.getItem('clientes') || '[]');
     if (id) {
       const idx = lista.findIndex(c => String(c.id) === String(id));
@@ -133,14 +134,34 @@ function Clientes() {
     localStorage.setItem('clientes', JSON.stringify(lista));
     alert('Cliente salvo');
     if (!id) setForm(initialForm);
+    setDirty(false);
   };
 
   const estados = [
     'AC','AL','AP','AM','BA','CE','DF','ES','GO','MA','MT','MS','MG','PA','PB','PR','PE','PI','RJ','RN','RS','RO','RR','SC','SP','SE','TO'
   ];
 
+  const handleSubmit = e => {
+    e.preventDefault();
+    salvar();
+  };
+
+  const cancelar = () => {
+    setForm(initialForm);
+    setDirty(false);
+  };
+
+  const sair = () => {
+    if (dirty) {
+      if (window.confirm('Deseja salvar as informações adicionadas?')) {
+        salvar();
+      }
+    }
+    navigate('..');
+  };
+
   return (
-    <form onSubmit={salvar} className="space-y-4">
+    <form onSubmit={handleSubmit} className="space-y-4">
       <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
         <label className="block">
           <span className="text-sm">Procedência</span>
@@ -264,11 +285,11 @@ function Clientes() {
       </div>
       <div className="flex gap-2">
         <Button type="submit">Salvar</Button>
-        <Button type="button" variant="secondary" onClick={() => navigate(-1)}>
+        <Button type="button" variant="secondary" onClick={cancelar}>
           Cancelar
         </Button>
-        <Button type="button" variant="secondary" onClick={() => navigate('lista')}>
-          Listar Clientes
+        <Button type="button" variant="secondary" onClick={sair}>
+          Sair
         </Button>
       </div>
     </form>

--- a/frontend-erp/src/modules/Cadastros/DadosEmpresa.jsx
+++ b/frontend-erp/src/modules/Cadastros/DadosEmpresa.jsx
@@ -21,6 +21,7 @@ function DadosEmpresa() {
     logo: null,
   };
   const [form, setForm] = useState(initialForm);
+  const [dirty, setDirty] = useState(false);
 
   useEffect(() => {
     const existente = JSON.parse(localStorage.getItem('empresa') || 'null');
@@ -30,6 +31,7 @@ function DadosEmpresa() {
   const handle = campo => e => {
     const value = campo === 'logo' ? e.target.files[0] : e.target.value;
     setForm(prev => ({ ...prev, [campo]: value }));
+    setDirty(true);
   };
 
   const buscarCEP = async () => {
@@ -52,8 +54,7 @@ function DadosEmpresa() {
     }
   };
 
-  const salvar = async (e) => {
-    e.preventDefault();
+  const salvar = async () => {
     const data = new FormData();
     Object.entries(form).forEach(([k, v]) => {
       if (v) data.append(k, v);
@@ -66,10 +67,30 @@ function DadosEmpresa() {
 
     localStorage.setItem('empresa', JSON.stringify(form));
     alert('Dados salvos');
+    setDirty(false);
+  };
+
+  const handleSubmit = e => {
+    e.preventDefault();
+    salvar();
+  };
+
+  const cancelar = () => {
+    setForm(initialForm);
+    setDirty(false);
+  };
+
+  const sair = async () => {
+    if (dirty) {
+      if (window.confirm('Deseja salvar as informações adicionadas?')) {
+        await salvar();
+      }
+    }
+    navigate('..');
   };
 
   return (
-    <form onSubmit={salvar} className="space-y-4">
+    <form onSubmit={handleSubmit} className="space-y-4">
       <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
         <label className="block">
           <span className="text-sm">Razão Social</span>
@@ -126,11 +147,11 @@ function DadosEmpresa() {
       </div>
       <div className="flex gap-2">
         <Button type="submit">Salvar</Button>
-        <Button type="button" variant="secondary" onClick={() => navigate(-1)}>
+        <Button type="button" variant="secondary" onClick={cancelar}>
           Cancelar
         </Button>
-        <Button type="button" variant="secondary" onClick={() => navigate('lista')}>
-          Listar Empresas
+        <Button type="button" variant="secondary" onClick={sair}>
+          Sair
         </Button>
       </div>
     </form>

--- a/frontend-erp/src/modules/Cadastros/Fornecedores.jsx
+++ b/frontend-erp/src/modules/Cadastros/Fornecedores.jsx
@@ -7,6 +7,7 @@ function Fornecedores() {
   const { id } = useParams();
   const initialForm = { nome: '', contato: '' };
   const [form, setForm] = useState(initialForm);
+  const [dirty, setDirty] = useState(false);
 
   useEffect(() => {
     if (id) {
@@ -18,10 +19,10 @@ function Fornecedores() {
 
   const handle = campo => e => {
     setForm(prev => ({ ...prev, [campo]: e.target.value }));
+    setDirty(true);
   };
 
-  const salvar = e => {
-    e.preventDefault();
+  const salvar = () => {
     const lista = JSON.parse(localStorage.getItem('fornecedores') || '[]');
     if (id) {
       const idx = lista.findIndex(f => String(f.id) === String(id));
@@ -33,10 +34,30 @@ function Fornecedores() {
     localStorage.setItem('fornecedores', JSON.stringify(lista));
     alert('Fornecedor salvo');
     if (!id) setForm(initialForm);
+    setDirty(false);
+  };
+
+  const handleSubmit = e => {
+    e.preventDefault();
+    salvar();
+  };
+
+  const cancelar = () => {
+    setForm(initialForm);
+    setDirty(false);
+  };
+
+  const sair = () => {
+    if (dirty) {
+      if (window.confirm('Deseja salvar as informações adicionadas?')) {
+        salvar();
+      }
+    }
+    navigate('..');
   };
 
   return (
-    <form onSubmit={salvar} className="space-y-4">
+    <form onSubmit={handleSubmit} className="space-y-4">
       <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
         <label className="block">
           <span className="text-sm">Nome</span>
@@ -49,10 +70,10 @@ function Fornecedores() {
       </div>
       <div className="flex gap-2">
         <Button type="submit">Salvar</Button>
-        <Button type="button" variant="secondary" onClick={() => navigate(-1)}>
+        <Button type="button" variant="secondary" onClick={cancelar}>
           Cancelar
         </Button>
-        <Button type="button" variant="secondary" onClick={() => navigate('lista')}>Listar Fornecedores</Button>
+        <Button type="button" variant="secondary" onClick={sair}>Sair</Button>
       </div>
     </form>
   );

--- a/frontend-erp/src/modules/Cadastros/Usuarios.jsx
+++ b/frontend-erp/src/modules/Cadastros/Usuarios.jsx
@@ -35,6 +35,7 @@ function Usuarios() {
   const { id } = useParams();
   const initialForm = { username: '', password: '', email: '', nome: '', cargo: '', permissoes: [] };
   const [form, setForm] = useState(initialForm);
+  const [dirty, setDirty] = useState(false);
 
   useEffect(() => {
     if (id) {
@@ -46,7 +47,10 @@ function Usuarios() {
         .catch(() => {});
     }
   }, [id]);
-  const handle = campo => e => setForm(prev => ({ ...prev, [campo]: e.target.value }));
+  const handle = campo => e => {
+    setForm(prev => ({ ...prev, [campo]: e.target.value }));
+    setDirty(true);
+  };
   const togglePermissao = (perm, checked) => {
     setForm(prev => ({
       ...prev,
@@ -54,6 +58,7 @@ function Usuarios() {
         ? [...prev.permissoes, perm]
         : prev.permissoes.filter(p => p !== perm)
     }));
+    setDirty(true);
   };
   const toggleGrupo = (grupo, checked) => {
     const permissoes = PERMISSOES_DISPONIVEIS[grupo];
@@ -63,10 +68,10 @@ function Usuarios() {
         ? Array.from(new Set([...prev.permissoes, ...permissoes]))
         : prev.permissoes.filter(p => !permissoes.includes(p))
     }));
+    setDirty(true);
   };
 
-  const salvar = async e => {
-    e.preventDefault();
+  const salvar = async () => {
     const url = id ? `/usuarios/${id}` : '/usuarios';
     const metodo = id ? 'PUT' : 'POST';
     await fetchComAuth(url, { method: metodo, body: JSON.stringify(form) });
@@ -76,10 +81,30 @@ function Usuarios() {
       setForm(initialForm);
     }
     alert('Usuário salvo');
+    setDirty(false);
+  };
+
+  const handleSubmit = e => {
+    e.preventDefault();
+    salvar();
+  };
+
+  const cancelar = () => {
+    setForm(initialForm);
+    setDirty(false);
+  };
+
+  const sair = async () => {
+    if (dirty) {
+      if (window.confirm('Deseja salvar as informações adicionadas?')) {
+        await salvar();
+      }
+    }
+    navigate('..');
   };
 
   return (
-    <form onSubmit={salvar} className="space-y-4">
+    <form onSubmit={handleSubmit} className="space-y-4">
       <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
         <label className="block"><span className="text-sm">Usuário</span><input className="input" value={form.username} onChange={handle('username')} /></label>
         <label className="block"><span className="text-sm">Senha</span><input type="text" className="input" value={form.password} onChange={handle('password')} /></label>
@@ -123,10 +148,10 @@ function Usuarios() {
       </div>
       <div className="flex gap-2">
         <Button type="submit">Salvar</Button>
-        <Button type="button" variant="secondary" onClick={() => navigate(-1)}>
+        <Button type="button" variant="secondary" onClick={cancelar}>
           Cancelar
         </Button>
-        <Button type="button" variant="secondary" onClick={() => navigate('lista')}>Listar Usuários</Button>
+        <Button type="button" variant="secondary" onClick={sair}>Sair</Button>
       </div>
     </form>
   );


### PR DESCRIPTION
## Summary
- add dirty state to forms to check for unsaved data
- implement Cancel and Sair behavior for cadastro forms
- warn when leaving without saving

## Testing
- `npm run lint` *(fails: cannot find '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685dc3f8c364832d90f2e5737476c7af