### PR TITLE
Add Puxador Cava Curvo operation

### DIFF
--- a/frontend-erp/src/modules/Producao/AppProducao.jsx
+++ b/frontend-erp/src/modules/Producao/AppProducao.jsx
@@ -216,13 +216,15 @@ const EditarPecaProducao = () => {
     const pos = form.posicao;
     let operacoesAtuais = [...operacoes];
 
-    if (operacao === "Puxador Cava") {
+    if (operacao === "Puxador Cava" || operacao === "Puxador Cava Curvo") {
+      const isCurvo = operacao === "Puxador Cava Curvo";
       const originalComprimento = parseFloat(dadosPeca.comprimento);
       const originalLargura = parseFloat(dadosPeca.largura);
       let novoComprimento = originalComprimento;
       let novaLargura = originalLargura;
       const ajuste = 25;
       let painelLargura;
+      const descontoLinha = isCurvo ? 75 : 0;
 
       if (pos.startsWith('C')) {
         novaLargura -= ajuste;
@@ -241,10 +243,12 @@ const EditarPecaProducao = () => {
 
       if (pos === "C1") {
         operacoesAtuais.push({ tipo: "Retângulo", x: 0, y: 0, largura: 55, comprimento: originalComprimento, profundidade: 6.5, estrategia: "Desbaste" });
-        operacoesAtuais.push({ tipo: "Linha", x: 0, y: 0, largura: 1, comprimento: originalComprimento, profundidade: 18.2, estrategia: "Linha" });
+        operacoesAtuais.push({ tipo: "Linha", x: 0, y: 0, largura: 1, comprimento: originalComprimento - descontoLinha, profundidade: 18.2, estrategia: "Linha" });
+        if (isCurvo) operacoesAtuais.push({ tipo: "Raio", pos, raio: 51 });
       } else if (pos === "C2") {
         operacoesAtuais.push({ tipo: "Retângulo", x: 0, y: originalLargura - 55, largura: 55, comprimento: originalComprimento, profundidade: 6.5, estrategia: "Desbaste" });
-        operacoesAtuais.push({ tipo: "Linha", x: 0, y: originalLargura - 1, largura: 1, comprimento: originalComprimento, profundidade: 18.2, estrategia: "Linha" });
+        operacoesAtuais.push({ tipo: "Linha", x: 0, y: originalLargura - 1, largura: 1, comprimento: originalComprimento - descontoLinha, profundidade: 18.2, estrategia: "Linha" });
+        if (isCurvo) operacoesAtuais.push({ tipo: "Raio", pos, raio: 51 });
       } else {
         let x_rect1 = 0;
         let x_line1 = 0;
@@ -253,7 +257,8 @@ const EditarPecaProducao = () => {
             x_line1 = novoComprimento - 1;
         }
         operacoesAtuais.push({ tipo: "Retângulo", x: x_rect1, y: 0, largura: originalLargura, comprimento: 55, profundidade: 6.5, estrategia: "Desbaste" });
-        operacoesAtuais.push({ tipo: "Linha", x: x_line1, y: 0, largura: originalLargura, comprimento: 1, profundidade: 18.2, estrategia: "Linha" });
+        operacoesAtuais.push({ tipo: "Linha", x: x_line1, y: 0, largura: originalLargura - descontoLinha, comprimento: 1, profundidade: 18.2, estrategia: "Linha" });
+        if (isCurvo) operacoesAtuais.push({ tipo: "Raio", pos, raio: 51 });
       }
 
       let newPecaId = parseInt(localStorage.getItem("globalPecaIdProducao")) || 1;
@@ -385,7 +390,7 @@ const EditarPecaProducao = () => {
   const cores = ["blue", "green", "orange", "purple"];
 
   const campos = () => {
-    if (["Puxador Cava", "Corte 45 graus"].includes(operacao)) {
+    if (["Puxador Cava", "Puxador Cava Curvo", "Corte 45 graus"].includes(operacao)) {
       return (
         <label className="block mt-2">Extremidade:
           <select className="input" value={form.posicao} onChange={e => setForm({ ...form, posicao: e.target.value })}>
@@ -476,12 +481,13 @@ const EditarPecaProducao = () => {
             <option>Furo</option>
             <option>Linha</option>
             <option>Puxador Cava</option>
+            <option>Puxador Cava Curvo</option>
             <option>Corte 45 graus</option>
           </select></label>
 
         {campos()}
 
-        { !["Puxador Cava", "Corte 45 graus"].includes(operacao) && (operacao === "Furo" ? <p className="mt-2">Estratégia: Por Dentro</p> : (
+        { !["Puxador Cava", "Puxador Cava Curvo", "Corte 45 graus"].includes(operacao) && (operacao === "Furo" ? <p className="mt-2">Estratégia: Por Dentro</p> : (
             <label className="block mt-2">Estratégia:
               <select className="input" value={form.estrategia} onChange={e => setForm({ ...form, estrategia: e.target.value })}>
                 <option>Por Dentro</option>

--- a/frontend-erp/src/modules/Producao/components/VisualizacaoPeca.jsx
+++ b/frontend-erp/src/modules/Producao/components/VisualizacaoPeca.jsx
@@ -28,18 +28,51 @@ const VisualizacaoPeca = ({ comprimento, largura, orientacao, operacoes = [] }) 
     }
   }
 
+  let raios = { topLeft: 0, topRight: 0, bottomRight: 0, bottomLeft: 0 };
+  operacoes = operacoes.filter(op => {
+    if (op.tipo === 'Raio') {
+      if (op.pos === 'L1') raios.topLeft = parseFloat(op.raio || 0) * escala;
+      if (op.pos === 'C1') raios.bottomRight = parseFloat(op.raio || 0) * escala;
+      if (op.pos === 'C2' || op.pos === 'L3') raios.topRight = parseFloat(op.raio || 0) * escala;
+      return false;
+    }
+    return true;
+  });
+
+  const pathD = () => {
+    const rTL = raios.topLeft || 0;
+    const rTR = raios.topRight || 0;
+    const rBR = raios.bottomRight || 0;
+    const rBL = raios.bottomLeft || 0;
+    let d = `M ${offsetX + rTL} ${offsetY}`;
+    d += ` H ${offsetX + larguraSVG - rTR}`;
+    if (rTR) d += ` A ${rTR} ${rTR} 0 0 1 ${offsetX + larguraSVG} ${offsetY + rTR}`;
+    d += ` V ${offsetY + alturaSVG - rBR}`;
+    if (rBR) d += ` A ${rBR} ${rBR} 0 0 1 ${offsetX + larguraSVG - rBR} ${offsetY + alturaSVG}`;
+    d += ` H ${offsetX + rBL}`;
+    if (rBL) d += ` A ${rBL} ${rBL} 0 0 1 ${offsetX} ${offsetY + alturaSVG - rBL}`;
+    d += ` V ${offsetY + rTL}`;
+    if (rTL) d += ` A ${rTL} ${rTL} 0 0 1 ${offsetX + rTL} ${offsetY}`;
+    d += ' Z';
+    return d;
+  };
+
   return (
     <svg width={viewWidth} height={viewHeight} viewBox={`0 0 ${viewWidth} ${viewHeight}`}>
       {/* Peça principal */}
-      <rect
-        x={offsetX}
-        y={offsetY}
-        width={larguraSVG}
-        height={alturaSVG}
-        fill="none"
-        stroke="#000"
-        strokeWidth={2}
-      />
+      { (raios.topLeft || raios.topRight || raios.bottomRight || raios.bottomLeft) ? (
+        <path d={pathD()} fill="none" stroke="#000" strokeWidth={2} />
+      ) : (
+        <rect
+          x={offsetX}
+          y={offsetY}
+          width={larguraSVG}
+          height={alturaSVG}
+          fill="none"
+          stroke="#000"
+          strokeWidth={2}
+        />
+      ) }
 
       {/* Face 1 com novo nome */}
       <rect


### PR DESCRIPTION
## Summary
- implement new "Puxador Cava Curvo" manual operation
- reduce cut line by 75mm and add corner radius when selected
- handle drawing rectangles with single-corner radius

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685e8e579868832d88ce76efea3ad1e4