### PR TITLE
Fix mirrored radius position for curved handle

### DIFF
--- a/frontend-erp/src/modules/Producao/AppProducao.jsx
+++ b/frontend-erp/src/modules/Producao/AppProducao.jsx
@@ -229,7 +229,7 @@ const espelharPuxadorCurvo = (ops = [], medida, eixo = 'Y') => {
         }
       }
       if (novo.tipo === 'Raio' && novo.pos === 'C1') {
-        novo.pos = 'L1';
+        novo.pos = 'L3';
       }
     } else {
       if (novo.y !== undefined) {


### PR DESCRIPTION
## Summary
- adjust how the curved handle radius is mirrored on the X axis so the arc stays on the bottom edge

## Testing
- `npm run lint` *(fails: Mixed spaces and tabs)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_685efb481514832d90dad8056174be51