### PR TITLE
Fix C1 mirroring for puxador cava curvo

### DIFF
--- a/frontend-erp/src/modules/Producao/AppProducao.jsx
+++ b/frontend-erp/src/modules/Producao/AppProducao.jsx
@@ -229,7 +229,7 @@ const espelharPuxadorCurvo = (ops = [], medida, eixo = 'Y') => {
         }
       }
       if (novo.tipo === 'Raio' && novo.pos === 'C1') {
-        novo.pos = 'L3';
+        // mantém a posição original para espelhar dentro da extremidade C1
       }
     } else {
       if (novo.y !== undefined) {


### PR DESCRIPTION
## Summary
- keep radius position as `C1` when mirroring curved handle

## Testing
- `npm run lint` *(fails: many existing eslint errors)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_685efeaf91ac832d9d2ce3fd573fae14