### PR TITLE
Fix missing username in sidebar after login

### DIFF
--- a/marketing-digital-ia/backend/services/auth_service.py
+++ b/marketing-digital-ia/backend/services/auth_service.py
@@ -38,7 +38,15 @@ def criar_token(usuario: dict) -> dict:
         SECRET_KEY,
         algorithm=ALGORITHM,
     )
-    return {"access_token": token, "usuario": {"username": usuario["username"], "permissoes": usuario.get("permissoes", [])}}
+    return {
+        "access_token": token,
+        "usuario": {
+            "username": usuario["username"],
+            "nome": usuario.get("nome"),
+            "cargo": usuario.get("cargo"),
+            "permissoes": usuario.get("permissoes", []),
+        },
+    }
 
 
 def decodificar_token(token: str) -> Optional[dict]:


### PR DESCRIPTION
## Summary
- include user details in auth login response so frontend shows the name

## Testing
- `python3 -m py_compile marketing-digital-ia/backend/services/auth_service.py`

------
https://chatgpt.com/codex/tasks/task_e_685f1433c028832d80b7e1da38f4c25d