### PR TITLE
Introduce Comercial module

### DIFF
--- a/comercial-backend/database.py
+++ b/comercial-backend/database.py
@@ -1,0 +1,37 @@
+import sqlite3
+import os
+from pathlib import Path
+
+DATA_DIR = Path(os.environ.get("RADHA_DATA_DIR", Path(__file__).resolve().parent))
+DATA_DIR.mkdir(parents=True, exist_ok=True)
+DB_PATH = DATA_DIR / "comercial.db"
+
+
+def get_db_connection():
+    conn = sqlite3.connect(DB_PATH)
+    conn.row_factory = sqlite3.Row
+    return conn
+
+
+def init_db():
+    conn = get_db_connection()
+    cur = conn.cursor()
+    cur.execute(
+        """CREATE TABLE IF NOT EXISTS atendimentos (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            cliente TEXT,
+            codigo TEXT,
+            projetos TEXT,
+            previsao_fechamento TEXT,
+            temperatura TEXT,
+            tem_especificador INTEGER,
+            especificador_nome TEXT,
+            rt_percent REAL,
+            historico TEXT
+        )"""
+    )
+    conn.commit()
+    conn.close()
+
+
+init_db()

--- a/comercial-backend/main.py
+++ b/comercial-backend/main.py
@@ -1,0 +1,60 @@
+from fastapi import FastAPI, Request
+from fastapi.responses import JSONResponse
+from database import get_db_connection
+
+app = FastAPI(redirect_slashes=False)
+
+
+@app.get("/")
+async def read_root():
+    return {"message": "Backend Comercial em execução"}
+
+
+@app.post("/atendimentos")
+async def criar_atendimento(request: Request):
+    data = await request.json()
+    fields = (
+        data.get("cliente"),
+        data.get("codigo"),
+        data.get("projetos"),
+        data.get("previsao_fechamento"),
+        data.get("temperatura"),
+        int(data.get("tem_especificador") or 0),
+        data.get("especificador_nome"),
+        data.get("rt_percent"),
+        data.get("historico"),
+    )
+    with get_db_connection() as conn:
+        cur = conn.execute(
+            """INSERT INTO atendimentos (
+                cliente, codigo, projetos, previsao_fechamento,
+                temperatura, tem_especificador, especificador_nome,
+                rt_percent, historico
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+            fields,
+        )
+        conn.commit()
+        new_id = cur.lastrowid
+    return {"id": new_id}
+
+
+@app.get("/atendimentos")
+async def listar_atendimentos():
+    with get_db_connection() as conn:
+        rows = conn.execute(
+            "SELECT id, cliente, codigo, previsao_fechamento, temperatura FROM atendimentos ORDER BY id DESC"
+        ).fetchall()
+        itens = [dict(row) for row in rows]
+    return {"atendimentos": itens}
+
+
+@app.get("/atendimentos/{atendimento_id}")
+async def obter_atendimento(atendimento_id: int):
+    with get_db_connection() as conn:
+        row = conn.execute(
+            "SELECT * FROM atendimentos WHERE id=?",
+            (atendimento_id,),
+        ).fetchone()
+        if not row:
+            return JSONResponse({"detail": "Atendimento não encontrado"}, status_code=404)
+        return {"atendimento": dict(row)}

--- a/comercial-backend/requirements.txt
+++ b/comercial-backend/requirements.txt
@@ -1,0 +1,2 @@
+fastapi
+uvicorn

--- a/frontend-erp/src/App.jsx
+++ b/frontend-erp/src/App.jsx
@@ -13,6 +13,7 @@ import {
 import MarketingDigitalIA from "./modules/MarketingDigitalIA";
 import Producao from "./modules/Producao";
 import Cadastros from "./modules/Cadastros";
+import Comercial from "./modules/Comercial";
 import Login from "./pages/Login";
 import { fetchComAuth } from "./utils/fetchComAuth";
 import { UserContext } from "./UserContext";
@@ -24,6 +25,7 @@ function Layout({ usuario, onLogout }) {
   const matchCadastros = useMatch("/cadastros/*");
   const matchMarketing = useMatch("/marketing-ia/*");
   const matchProducao = useMatch("/producao/*");
+  const matchComercial = useMatch("/comercial/*");
 
   return (
     <div className="min-h-screen flex">
@@ -53,6 +55,14 @@ function Layout({ usuario, onLogout }) {
               className={`px-2 py-1 rounded ${matchProducao ? "bg-blue-700" : "hover:bg-blue-700"}`}
             >
               Produção
+            </Link>
+          )}
+          {possuiPermissao("comercial") && (
+            <Link
+              to="/comercial"
+              className={`px-2 py-1 rounded ${matchComercial ? "bg-blue-700" : "hover:bg-blue-700"}`}
+            >
+              Comercial
             </Link>
           )}
         </nav>
@@ -150,6 +160,7 @@ function App() {
           <Route path="cadastros/*" element={<Cadastros />} />
           <Route path="marketing-ia/*" element={<MarketingDigitalIA />} />
           <Route path="producao/*" element={<Producao />} />
+          <Route path="comercial/*" element={<Comercial />} />
         </Route>
 
         <Route path="/login" element={<Login onLoginSuccess={handleLoginSuccess} />} />

--- a/frontend-erp/src/modules/Comercial/index.jsx
+++ b/frontend-erp/src/modules/Comercial/index.jsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import { Routes, Route, Link, Outlet, useResolvedPath, useMatch } from 'react-router-dom';
+import { useUsuario } from '../../UserContext';
+import Atendimentos from './pages/Atendimentos';
+import AtendimentoForm from './pages/AtendimentoForm';
+
+function ComercialLayout() {
+  const resolved = useResolvedPath('');
+  const matchAtendimentos = useMatch({ path: `${resolved.pathname}`, end: true });
+  const usuario = useUsuario();
+  const possuiPermissao = p => usuario?.permissoes?.includes(p);
+
+  return (
+    <div className="p-4 bg-white rounded shadow-md">
+      <h2 className="text-xl font-bold mb-4 text-blue-700">Módulo: Comercial</h2>
+      <nav className="flex gap-4 mb-4 border-b pb-2">
+        {possuiPermissao('comercial/atendimentos') && (
+          <Link
+            to="."
+            className={`px-3 py-1 rounded ${matchAtendimentos ? 'bg-blue-200 text-blue-800' : 'text-blue-600 hover:bg-blue-100'}`}
+          >
+            Atendimentos
+          </Link>
+        )}
+      </nav>
+      <Outlet />
+    </div>
+  );
+}
+
+function Comercial() {
+  return (
+    <Routes>
+      <Route path="/" element={<ComercialLayout />}>
+        <Route index element={<Atendimentos />} />
+        <Route path="novo" element={<AtendimentoForm />} />
+      </Route>
+    </Routes>
+  );
+}
+
+export default Comercial;

--- a/frontend-erp/src/modules/Comercial/pages/AtendimentoForm.jsx
+++ b/frontend-erp/src/modules/Comercial/pages/AtendimentoForm.jsx
@@ -1,0 +1,40 @@
+import React, { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { fetchComAuth } from '../../../utils/fetchComAuth';
+
+function AtendimentoForm() {
+  const [cliente, setCliente] = useState('');
+  const navigate = useNavigate();
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    try {
+      await fetchComAuth('/comercial/atendimentos', {
+        method: 'POST',
+        body: JSON.stringify({ cliente }),
+      });
+      navigate('..');
+    } catch (err) {
+      console.error('Erro ao criar atendimento', err);
+    }
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4">
+      <div>
+        <label className="block mb-1">Cliente</label>
+        <input
+          type="text"
+          value={cliente}
+          onChange={(e) => setCliente(e.target.value)}
+          className="border p-1 rounded w-full"
+        />
+      </div>
+      <button type="submit" className="bg-blue-600 text-white px-3 py-1 rounded hover:bg-blue-700">
+        Salvar
+      </button>
+    </form>
+  );
+}
+
+export default AtendimentoForm;

--- a/frontend-erp/src/modules/Comercial/pages/Atendimentos.jsx
+++ b/frontend-erp/src/modules/Comercial/pages/Atendimentos.jsx
@@ -1,0 +1,38 @@
+import React, { useEffect, useState } from 'react';
+import { Link } from 'react-router-dom';
+import { fetchComAuth } from '../../../utils/fetchComAuth';
+
+function Atendimentos() {
+  const [atendimentos, setAtendimentos] = useState([]);
+
+  useEffect(() => {
+    const carregar = async () => {
+      try {
+        const dados = await fetchComAuth('/comercial/atendimentos');
+        setAtendimentos(dados.atendimentos);
+      } catch (err) {
+        console.error('Erro ao carregar atendimentos', err);
+      }
+    };
+    carregar();
+  }, []);
+
+  return (
+    <div>
+      <div className="flex justify-end mb-4">
+        <Link to="novo" className="bg-blue-600 text-white px-3 py-1 rounded hover:bg-blue-700">
+          Novo Atendimento
+        </Link>
+      </div>
+      <ul className="space-y-2">
+        {atendimentos.map((at) => (
+          <li key={at.id} className="p-2 border rounded bg-gray-50">
+            <span className="font-medium">{at.codigo}</span> - {at.cliente}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+export default Atendimentos;

--- a/frontend-erp/src/utils/fetchComAuth.js
+++ b/frontend-erp/src/utils/fetchComAuth.js
@@ -23,6 +23,8 @@ export async function fetchComAuth(url, options = {}) {
           finalUrl = `${GATEWAY_URL}/marketing-ia${url}`; // Rotas do Marketing Digital IA via Gateway
         } else if (url.startsWith('/importar-xml') || url.startsWith('/gerar-lote-final') || url.startsWith('/carregar-lote-final') || url.startsWith('/executar-nesting') || url.startsWith('/listar-lotes') || url.startsWith('/excluir-lote') || url.startsWith('/config-maquina') || url.startsWith('/config-ferramentas') || url.startsWith('/config-cortes') || url.startsWith('/config-layers') || url.startsWith('/chapas') || url.startsWith('/coletar-layers') || url.startsWith('/lotes-ocorrencias') || url.startsWith('/motivos-ocorrencias') || url.startsWith('/relatorio-ocorrencias') || url.startsWith('/nestings') || url.startsWith('/remover-nesting')) {
             finalUrl = `${GATEWAY_URL}/producao${url}`; // Rotas de Produção via Gateway
+        } else if (url.startsWith('/comercial')) {
+            finalUrl = `${GATEWAY_URL}/comercial${url}`; // Rotas do módulo Comercial via Gateway
         } else if (url.startsWith('/auth') || url.startsWith('/usuarios') || url.startsWith('/empresa')) {
           finalUrl = `${GATEWAY_URL}${url}`; // Endpoints atendidos diretamente pelo Gateway
       }


### PR DESCRIPTION
## Summary
- add Comercial backend with simple atendimentos API
- route comercial API through gateway
- add initial Comercial frontend module with basic pages
- update fetch helper for Comercial routing

## Testing
- `python -m py_compile comercial-backend/*.py backend-gateway/*.py`
- `npm --prefix frontend-erp run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685f1edf1768832daef89cfa44c9b967