### PR TITLE
Fix Comercial module visibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,10 @@ When the application is started for the first time and the user database is empt
 it will create a default administrator account. You can override the username and
 password using the `RADHA_ADMIN_USER` and `RADHA_ADMIN_PASS` environment
 variables. The default values are `admin` / `admin`.
+The default admin receives access to all modules, including the recently added
+`comercial` section. If your database was created before this permission was
+added, update the `permissoes` field for the admin user to include
+`comercial`.
 
 
 ## Troubleshooting

--- a/marketing-digital-ia/backend/database.py
+++ b/marketing-digital-ia/backend/database.py
@@ -41,7 +41,7 @@ def init_db():
                 "admin@example.com",
                 "Administrador",
                 "admin",
-                "[\"chat\", \"campanhas\", \"publicacoes\", \"publico\", \"marketing-ia\", \"producao\", \"cadastros\"]",
+                "[\"chat\", \"campanhas\", \"publicacoes\", \"publico\", \"marketing-ia\", \"producao\", \"cadastros\", \"comercial\"]",
             ),
         )
         conn.commit()


### PR DESCRIPTION
## Summary
- give default admin access to the new Comercial module
- document Comercial permission in the README

## Testing
- `pytest -q`
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685f206bd0f8832d9cdf0eab17bb2fde