### PR TITLE
Fix missing Comercial permissions

### DIFF
--- a/frontend-erp/src/modules/Cadastros/Usuarios.jsx
+++ b/frontend-erp/src/modules/Cadastros/Usuarios.jsx
@@ -27,6 +27,10 @@ const PERMISSOES_DISPONIVEIS = {
     'cadastros/clientes',
     'cadastros/fornecedores',
     'cadastros/usuarios'
+  ],
+  'Comercial': [
+    'comercial',
+    'comercial/atendimentos'
   ]
 };
 


### PR DESCRIPTION
## Summary
- add a "Comercial" group with its permissions so that users can enable access to the Comercial module

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685f21e14368832d8ef10a6fa26bfd37