### PR TITLE
Fix atendimento form fields

### DIFF
--- a/frontend-erp/src/modules/Comercial/pages/AtendimentoForm.jsx
+++ b/frontend-erp/src/modules/Comercial/pages/AtendimentoForm.jsx
@@ -1,17 +1,37 @@
 import React, { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
+import { Button } from '../../Producao/components/ui/button';
 import { fetchComAuth } from '../../../utils/fetchComAuth';
 
 function AtendimentoForm() {
-  const [cliente, setCliente] = useState('');
+  const [form, setForm] = useState({
+    cliente: '',
+    codigo: '',
+    projetos: '',
+    previsao_fechamento: '',
+    temperatura: '',
+    tem_especificador: false,
+    especificador_nome: '',
+    rt_percent: '',
+    historico: '',
+  });
   const navigate = useNavigate();
 
-  const handleSubmit = async (e) => {
+  const handle = campo => e => {
+    const value =
+      campo === 'tem_especificador' ? e.target.checked : e.target.value;
+    setForm(prev => ({ ...prev, [campo]: value }));
+  };
+
+  const handleSubmit = async e => {
     e.preventDefault();
     try {
       await fetchComAuth('/comercial/atendimentos', {
         method: 'POST',
-        body: JSON.stringify({ cliente }),
+        body: JSON.stringify({
+          ...form,
+          tem_especificador: form.tem_especificador ? 1 : 0,
+        }),
       });
       navigate('..');
     } catch (err) {
@@ -21,18 +41,91 @@ function AtendimentoForm() {
 
   return (
     <form onSubmit={handleSubmit} className="space-y-4">
-      <div>
-        <label className="block mb-1">Cliente</label>
-        <input
-          type="text"
-          value={cliente}
-          onChange={(e) => setCliente(e.target.value)}
-          className="border p-1 rounded w-full"
-        />
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+        <label className="block">
+          <span className="text-sm">Cliente</span>
+          <input
+            className="input"
+            value={form.cliente}
+            onChange={handle('cliente')}
+          />
+        </label>
+        <label className="block">
+          <span className="text-sm">Código</span>
+          <input
+            className="input"
+            value={form.codigo}
+            onChange={handle('codigo')}
+          />
+        </label>
+        <label className="block md:col-span-2">
+          <span className="text-sm">Projetos</span>
+          <input
+            className="input"
+            value={form.projetos}
+            onChange={handle('projetos')}
+          />
+        </label>
+        <label className="block">
+          <span className="text-sm">Previsão Fechamento</span>
+          <input
+            type="date"
+            className="input"
+            value={form.previsao_fechamento}
+            onChange={handle('previsao_fechamento')}
+          />
+        </label>
+        <label className="block">
+          <span className="text-sm">Temperatura</span>
+          <select
+            className="input"
+            value={form.temperatura}
+            onChange={handle('temperatura')}
+          >
+            <option value="">Selecione</option>
+            <option value="Fria">Fria</option>
+            <option value="Morna">Morna</option>
+            <option value="Quente">Quente</option>
+          </select>
+        </label>
+        <label className="inline-flex items-center gap-1">
+          <input
+            type="checkbox"
+            checked={form.tem_especificador}
+            onChange={handle('tem_especificador')}
+          />
+          Possui Especificador
+        </label>
+        <label className="block">
+          <span className="text-sm">Nome do Especificador</span>
+          <input
+            className="input"
+            value={form.especificador_nome}
+            onChange={handle('especificador_nome')}
+            disabled={!form.tem_especificador}
+          />
+        </label>
+        <label className="block">
+          <span className="text-sm">% RT</span>
+          <input
+            type="number"
+            step="0.01"
+            className="input"
+            value={form.rt_percent}
+            onChange={handle('rt_percent')}
+          />
+        </label>
+        <label className="block md:col-span-2">
+          <span className="text-sm">Histórico</span>
+          <textarea
+            className="input"
+            rows="4"
+            value={form.historico}
+            onChange={handle('historico')}
+          />
+        </label>
       </div>
-      <button type="submit" className="bg-blue-600 text-white px-3 py-1 rounded hover:bg-blue-700">
-        Salvar
-      </button>
+      <Button type="submit">Salvar</Button>
     </form>
   );
 }


### PR DESCRIPTION
## Summary
- add missing fields to Comercial atendimento form

## Testing
- `npm --prefix frontend-erp run lint` *(fails: no-unused-vars and other errors)*

------
https://chatgpt.com/codex/tasks/task_e_685fd57abd04832d85587c7c8a1a3e1d