### PR TITLE
Add basic tasks support to Comercial atendimentos

### DIFF
--- a/comercial-backend/database.py
+++ b/comercial-backend/database.py
@@ -30,6 +30,16 @@ def init_db():
             historico TEXT
         )"""
     )
+    cur.execute(
+        """CREATE TABLE IF NOT EXISTS atendimento_tarefas (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            atendimento_id INTEGER,
+            nome TEXT,
+            concluida INTEGER DEFAULT 0,
+            dados TEXT,
+            FOREIGN KEY (atendimento_id) REFERENCES atendimentos(id)
+        )"""
+    )
     conn.commit()
     conn.close()
 

--- a/frontend-erp/src/modules/Comercial/pages/AtendimentoForm.jsx
+++ b/frontend-erp/src/modules/Comercial/pages/AtendimentoForm.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { Button } from '../../Producao/components/ui/button';
 import { fetchComAuth } from '../../../utils/fetchComAuth';
@@ -16,6 +16,18 @@ function AtendimentoForm() {
     historico: '',
   });
   const navigate = useNavigate();
+
+  useEffect(() => {
+    const carregarCodigo = async () => {
+      try {
+        const resp = await fetchComAuth('/comercial/atendimentos/proximo-codigo');
+        setForm(prev => ({ ...prev, codigo: resp.codigo }));
+      } catch (err) {
+        console.error('Erro ao obter código', err);
+      }
+    };
+    carregarCodigo();
+  }, []);
 
   const handle = campo => e => {
     const value =
@@ -53,9 +65,9 @@ function AtendimentoForm() {
         <label className="block">
           <span className="text-sm">Código</span>
           <input
-            className="input"
+            className="input bg-gray-100"
             value={form.codigo}
-            onChange={handle('codigo')}
+            readOnly
           />
         </label>
         <label className="block md:col-span-2">


### PR DESCRIPTION
## Summary
- create table `atendimento_tarefas`
- generate sequential codes and create initial tasks for new atendimentos
- expose endpoints for next code and tasks management
- auto-fill codigo field in AtendimentoForm and make it read-only

## Testing
- `python -m py_compile comercial-backend/main.py backend-gateway/main.py comercial-backend/database.py`
- `npm run lint` *(fails: 56 errors)*

------
https://chatgpt.com/codex/tasks/task_e_685fdb947c9c832db621588161dc8874