### PR TITLE
Fix start script and comercial URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,5 +26,5 @@ sudo apt install python3 python3-venv nodejs npm
 O serviço `radha-erp.service` é um exemplo de unidade systemd para produção.
 
 ## Suporte
-Caso o navegador exiba apenas uma tela de carregamento, verifique se as APIs estão em execução e se as portas 8010, 8015 e 8020 não estão ocupadas. Consulte os arquivos de log de cada serviço para mais detalhes.
+Caso o navegador exiba apenas uma tela de carregamento, verifique se as APIs estão em execução e se as portas 8010, 8015, 8020 e 8030 não estão ocupadas. Consulte os arquivos de log de cada serviço para mais detalhes.
 

--- a/frontend-erp/src/utils/fetchComAuth.js
+++ b/frontend-erp/src/utils/fetchComAuth.js
@@ -24,7 +24,7 @@ export async function fetchComAuth(url, options = {}) {
         } else if (url.startsWith('/importar-xml') || url.startsWith('/gerar-lote-final') || url.startsWith('/carregar-lote-final') || url.startsWith('/executar-nesting') || url.startsWith('/listar-lotes') || url.startsWith('/excluir-lote') || url.startsWith('/config-maquina') || url.startsWith('/config-ferramentas') || url.startsWith('/config-cortes') || url.startsWith('/config-layers') || url.startsWith('/chapas') || url.startsWith('/coletar-layers') || url.startsWith('/lotes-ocorrencias') || url.startsWith('/motivos-ocorrencias') || url.startsWith('/relatorio-ocorrencias') || url.startsWith('/nestings') || url.startsWith('/remover-nesting')) {
             finalUrl = `${GATEWAY_URL}/producao${url}`; // Rotas de Produção via Gateway
         } else if (url.startsWith('/comercial')) {
-            finalUrl = `${GATEWAY_URL}/comercial${url}`; // Rotas do módulo Comercial via Gateway
+            finalUrl = `${GATEWAY_URL}${url}`; // Rotas do módulo Comercial via Gateway
         } else if (url.startsWith('/auth') || url.startsWith('/usuarios') || url.startsWith('/empresa')) {
           finalUrl = `${GATEWAY_URL}${url}`; // Endpoints atendidos diretamente pelo Gateway
       }

--- a/rodar_ambientes.txt
+++ b/rodar_ambientes.txt
@@ -21,7 +21,13 @@ source venv/bin/activate
 export SECRET_KEY=radha-super-secreto
 uvicorn main:app --host 0.0.0.0 --port 8010 --reload
 
-# --- TERMINAL 4: Frontend Principal (Porta 3005) ---
+# --- TERMINAL 4: Backend Comercial (Porta 8030) ---
+cd /opt/radha/radha-erp/comercial-backend/
+source venv/bin/activate
+export SECRET_KEY=radha-super-secreto
+uvicorn main:app --host 0.0.0.0 --port 8030 --reload
+
+# --- TERMINAL 5: Frontend Principal (Porta 3005) ---
 cd /opt/radha/radha-erp/frontend-erp/
 # Se algum ambiente virtual Python estiver ativo (mostrar "(venv)"), desative:
 # deactivate

--- a/start_services.sh
+++ b/start_services.sh
@@ -8,6 +8,8 @@ cd "$DIR/producao/backend/src" && source venv/bin/activate && uvicorn api:app --
 PID2=$!
 cd "$DIR/backend-gateway" && source venv/bin/activate && uvicorn main:app --host 0.0.0.0 --port 8010 --reload &
 PID3=$!
-cd "$DIR/frontend-erp" && npm run dev &
+cd "$DIR/comercial-backend" && source venv/bin/activate && uvicorn main:app --host 0.0.0.0 --port 8030 --reload &
 PID4=$!
-wait $PID1 $PID2 $PID3 $PID4
+cd "$DIR/frontend-erp" && npm run dev &
+PID5=$!
+wait $PID1 $PID2 $PID3 $PID4 $PID5


### PR DESCRIPTION
## Summary
- correct gateway URL prefix for comercial API calls
- start comercial backend in start_services.sh
- update commands for running services separately
- document commercial backend port in README

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_685fedfad464832db1e7599a4e34d078