### PR TITLE
Highlight peças editadas manualmente

### DIFF
--- a/frontend-erp/src/modules/Producao/AppProducao.jsx
+++ b/frontend-erp/src/modules/Producao/AppProducao.jsx
@@ -85,6 +85,7 @@ const LoteProducao = () => {
         if (p.operacoes) {
           localStorage.setItem("op_producao_" + id, JSON.stringify(p.operacoes));
         }
+        localStorage.setItem("editado_peca_" + id, "false");
         return { ...p, id };
       });
       const ferragensComIds = (pacote.ferragens || []).map(f => ({
@@ -394,6 +395,7 @@ const espelharPuxadorCurvo = (ops = [], medida, eixo = 'Y') => {
     setOperacoes(operacoesAtuais);
     const chaveOp = origemOcorrencia ? "ocedit_op_" + pecaId : "op_producao_" + pecaId;
     localStorage.setItem(chaveOp, JSON.stringify(operacoesAtuais));
+    localStorage.setItem(`editado_peca_${pecaId}`, operacoesAtuais.length > 0 ? "true" : "false");
     setForm({ comprimento: "", largura: "", profundidade: "", diametro: "", x: 0, y: 0, estrategia: "Por Dentro", posicao: "C1", face: "Face (F0)" });
     setEspelhar(false);
   };
@@ -402,6 +404,7 @@ const espelharPuxadorCurvo = (ops = [], medida, eixo = 'Y') => {
     setOperacoes([]);
     const chaveOp = origemOcorrencia ? "ocedit_op_" + pecaId : "op_producao_" + pecaId;
     localStorage.removeItem(chaveOp);
+    localStorage.setItem(`editado_peca_${pecaId}`, "false");
   };
 
   const excluirUma = (index) => {
@@ -409,6 +412,7 @@ const espelharPuxadorCurvo = (ops = [], medida, eixo = 'Y') => {
     setOperacoes(novas);
     const chaveOp = origemOcorrencia ? "ocedit_op_" + pecaId : "op_producao_" + pecaId;
     localStorage.setItem(chaveOp, JSON.stringify(novas));
+    localStorage.setItem(`editado_peca_${pecaId}`, novas.length > 0 ? "true" : "false");
   };
 
   const editarUma = (index) => {
@@ -424,6 +428,7 @@ const espelharPuxadorCurvo = (ops = [], medida, eixo = 'Y') => {
     setOperacoes(novas);
     const chaveOp = origemOcorrencia ? "ocedit_op_" + pecaId : "op_producao_" + pecaId;
     localStorage.setItem(chaveOp, JSON.stringify(novas));
+    localStorage.setItem(`editado_peca_${pecaId}`, novas.length > 0 ? "true" : "false");
   };
 
   const desfazerPuxador = () => {
@@ -434,6 +439,7 @@ const espelharPuxadorCurvo = (ops = [], medida, eixo = 'Y') => {
     setOperacoes(dados.operacoes || []);
     const chaveOp = origemOcorrencia ? "ocedit_op_" + pecaId : "op_producao_" + pecaId;
     localStorage.setItem(chaveOp, JSON.stringify(dados.operacoes || []));
+    localStorage.setItem(`editado_peca_${pecaId}`, (dados.operacoes || []).length > 0 ? "true" : "false");
     if (!origemOcorrencia) {
       const lotes = JSON.parse(localStorage.getItem("lotesProducao") || "[]");
       const atualizados = lotes.map(l =>
@@ -477,6 +483,7 @@ const espelharPuxadorCurvo = (ops = [], medida, eixo = 'Y') => {
     setOperacoes(opsEscaladas);
     const chaveOp = origemOcorrencia ? "ocedit_op_" + pecaId : "op_producao_" + pecaId;
     localStorage.setItem(chaveOp, JSON.stringify(opsEscaladas));
+    localStorage.setItem(`editado_peca_${pecaId}`, opsEscaladas.length > 0 ? "true" : "false");
 
     if (origemOcorrencia) {
       localStorage.setItem(

--- a/frontend-erp/src/modules/Producao/components/Pacote.jsx
+++ b/frontend-erp/src/modules/Producao/components/Pacote.jsx
@@ -86,8 +86,7 @@ const Pacote = () => {
 
       <ul className="space-y-2">
         {pecasFiltradas.map((p) => {
-          const ops = JSON.parse(localStorage.getItem("op_producao_" + p.id) || "[]");
-          const editado = ops.length > 0;
+          const editado = localStorage.getItem("editado_peca_" + p.id) === "true";
           return (
             <li key={p.id} className={`border rounded p-3 ${editado ? 'bg-yellow-100' : ''}`}>
               <p><strong>ID {String(p.id).padStart(6,'0')} ({p.codigo_peca})</strong>: {p.nome} - {p.comprimento} x {p.largura} mm</p>


### PR DESCRIPTION
## Summary
- track user-edited pieces with `editado_peca_<id>` flag
- color rows in Pacote list only when flag is true

## Testing
- `npm run lint` *(fails: 56 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68600ac9875c832da524683eb7691a36