### PR TITLE
Fix parse error in PacoteOcorrencia.jsx

### DIFF
--- a/frontend-erp/src/modules/Producao/components/PacoteOcorrencia.jsx
+++ b/frontend-erp/src/modules/Producao/components/PacoteOcorrencia.jsx
@@ -161,7 +161,8 @@ const PacoteOcorrencia = () => {
                 </Button>
               </div>
             </li>
-          ))}
+          );
+        })}
         </ul>
       )}
       <div className="flex gap-2">


### PR DESCRIPTION
## Summary
- close PacoteOcorrencia list map correctly to avoid build failure

## Testing
- `npm run lint` *(fails: Mixed spaces and tabs errors, unused vars, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68600eb80754832dbe0686d0d2dd4537