### PR TITLE
Fix occurrence edit flag

### DIFF
--- a/frontend-erp/src/modules/Producao/components/PacoteOcorrencia.jsx
+++ b/frontend-erp/src/modules/Producao/components/PacoteOcorrencia.jsx
@@ -62,7 +62,7 @@ const PacoteOcorrencia = () => {
         const novoId = nextId++;
         idsOriginais.push(p.id);
         localStorage.setItem("op_producao_" + novoId, JSON.stringify(ops));
-        const editFlag = localStorage.getItem("editado_peca_" + p.id) || (ops.length > 0 ? "true" : "false");
+        const editFlag = localStorage.getItem("editado_peca_" + p.id) || "false";
         localStorage.setItem("editado_peca_" + novoId, editFlag);
         return {
           ...p,


### PR DESCRIPTION
## Summary
- ensure `editado_peca_*` is only set when explicitly flagged during
  occurrence package generation

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_686012e086a4832d998c9e2da4e0d8a7