### PR TITLE
Adjust finalize path for occurrence edit

### DIFF
--- a/frontend-erp/src/modules/Producao/AppProducao.jsx
+++ b/frontend-erp/src/modules/Producao/AppProducao.jsx
@@ -647,13 +647,13 @@ const espelharPuxadorCurvo = (ops = [], medida, eixo = 'Y') => {
           )}
           <Button
             variant="outline"
-            onClick={() =>
-              origemOcorrencia
-                ? navigate('/producao/ocorrencias', { state: { ocId } })
-                : pacoteIndex !== undefined
-                  ? navigate(`/producao/lote/${nome}/pacote/${pacoteIndex}`)
-                  : navigate(`/producao/lote/${nome}`)
-            }
+              onClick={() =>
+                origemOcorrencia
+                  ? navigate(`/producao/ocorrencias/pacote/${ocId}`)
+                  : pacoteIndex !== undefined
+                    ? navigate(`/producao/lote/${nome}/pacote/${pacoteIndex}`)
+                    : navigate(`/producao/lote/${nome}`)
+              }
           >
             Finalizar
           </Button>


### PR DESCRIPTION
## Summary
- direct finalize button on EditarPeca to return to the occurrence package

## Testing
- `npm run lint` *(fails: cannot find some lint dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_686018cccad4832dabb9ebfab08191a4