### PR TITLE
Fix stray line in payment conditions form

### DIFF
--- a/frontend-erp/src/modules/Cadastros/CondicaoPagamento.jsx
+++ b/frontend-erp/src/modules/Cadastros/CondicaoPagamento.jsx
@@ -42,7 +42,6 @@ function CondicaoPagamento() {
   const adicionarParcela = tipo => {
     setForm(prev => ({
       ...prev,
-g1b3co-codex/adicionar-tela-de-cadastro-com-tabela-e-importação
       [tipo]: [
         ...prev[tipo],
         {


### PR DESCRIPTION
## Summary
- remove stray codex note from `CondicaoPagamento.jsx`

## Testing
- `npm run lint` *(fails: Mixed spaces and tabs, other existing errors)*

------
https://chatgpt.com/codex/tasks/task_e_68601e1a5344832db801e12b7bbbf6ae