### PR TITLE
Fix payment terms validation

### DIFF
--- a/frontend-erp/src/modules/Cadastros/CondicaoPagamento.jsx
+++ b/frontend-erp/src/modules/Cadastros/CondicaoPagamento.jsx
@@ -59,10 +59,13 @@ function CondicaoPagamento() {
   };
 
   const salvar = async () => {
+    const parcelas = parseInt(form.numero_parcelas, 10);
+    const juros = parseFloat(form.juros_parcela);
+
     const body = {
       nome: form.nome,
-      numero_parcelas: parseInt(form.numero_parcelas, 10),
-      juros_parcela: parseFloat(form.juros_parcela || 0),
+      numero_parcelas: Number.isFinite(parcelas) ? parcelas : 1,
+      juros_parcela: Number.isFinite(juros) ? juros : 0,
       dias_vencimento: form.dias_vencimento,
       ativa: form.ativa ? 1 : 0,
     };


### PR DESCRIPTION
## Summary
- validate numeric fields before posting payment terms so NaN doesn't get sent

## Testing
- `npm run lint` *(fails: various lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68602a1e55c8832da6ea3ba0f6ff617b