### PR TITLE
Add delete option for Atendimentos

### DIFF
--- a/comercial-backend/main.py
+++ b/comercial-backend/main.py
@@ -138,6 +138,21 @@ async def atualizar_tarefa(atendimento_id: int, tarefa_id: int, request: Request
     return {"ok": True}
 
 
+@app.delete("/atendimentos/{atendimento_id}")
+async def excluir_atendimento(atendimento_id: int):
+    with get_db_connection() as conn:
+        conn.execute(
+            "DELETE FROM atendimento_tarefas WHERE atendimento_id=?",
+            (atendimento_id,),
+        )
+        conn.execute(
+            "DELETE FROM atendimentos WHERE id=?",
+            (atendimento_id,),
+        )
+        conn.commit()
+    return {"ok": True}
+
+
 @app.get("/condicoes-pagamento")
 async def listar_condicoes():
     with get_db_connection() as conn:

--- a/frontend-erp/src/modules/Comercial/pages/Atendimentos.jsx
+++ b/frontend-erp/src/modules/Comercial/pages/Atendimentos.jsx
@@ -1,21 +1,29 @@
 import React, { useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
+import { Button } from '../../Producao/components/ui/button';
 import { fetchComAuth } from '../../../utils/fetchComAuth';
 
 function Atendimentos() {
   const [atendimentos, setAtendimentos] = useState([]);
 
+  const carregar = async () => {
+    try {
+      const dados = await fetchComAuth('/comercial/atendimentos');
+      setAtendimentos(dados.atendimentos);
+    } catch (err) {
+      console.error('Erro ao carregar atendimentos', err);
+    }
+  };
+
   useEffect(() => {
-    const carregar = async () => {
-      try {
-        const dados = await fetchComAuth('/comercial/atendimentos');
-        setAtendimentos(dados.atendimentos);
-      } catch (err) {
-        console.error('Erro ao carregar atendimentos', err);
-      }
-    };
     carregar();
   }, []);
+
+  const remover = async (id) => {
+    if (!window.confirm('Excluir atendimento?')) return;
+    await fetchComAuth(`/comercial/atendimentos/${id}`, { method: 'DELETE' });
+    carregar();
+  };
 
   return (
     <div>
@@ -26,10 +34,16 @@ function Atendimentos() {
       </div>
       <ul className="space-y-2">
         {atendimentos.map((at) => (
-          <li key={at.id} className="p-2 border rounded bg-gray-50">
-            <Link to={String(at.id)} className="hover:underline">
+          <li
+            key={at.id}
+            className="p-2 border rounded bg-gray-50 flex justify-between items-center"
+          >
+            <Link to={String(at.id)} className="hover:underline flex-1">
               <span className="font-medium">{at.codigo}</span> - {at.cliente}
             </Link>
+            <Button size="sm" variant="destructive" onClick={() => remover(at.id)}>
+              Excluir
+            </Button>
           </li>
         ))}
       </ul>


### PR DESCRIPTION
## Summary
- allow deleting atendimentos in backend API
- show "Excluir" button beside each item in Cadastros/Atendimentos

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `python -m py_compile comercial-backend/main.py`

------
https://chatgpt.com/codex/tasks/task_e_68616c2798d8832db1e20f36dd48fdb0