### PR TITLE
Fix date and task display on Atendimentos

### DIFF
--- a/comercial-backend/database.py
+++ b/comercial-backend/database.py
@@ -28,7 +28,8 @@ def init_db():
             especificador_nome TEXT,
             rt_percent REAL,
             historico TEXT,
-            arquivos_json TEXT
+            arquivos_json TEXT,
+            data_cadastro TEXT DEFAULT CURRENT_TIMESTAMP
         )"""
     )
     cur.execute(
@@ -58,6 +59,10 @@ def init_db():
     cols_a = [row[1] for row in cur.execute("PRAGMA table_info(atendimentos)")]
     if "arquivos_json" not in cols_a:
         cur.execute("ALTER TABLE atendimentos ADD COLUMN arquivos_json TEXT")
+    if "data_cadastro" not in cols_a:
+        cur.execute(
+            "ALTER TABLE atendimentos ADD COLUMN data_cadastro TEXT DEFAULT CURRENT_TIMESTAMP"
+        )
     conn.commit()
     conn.close()
 

--- a/comercial-backend/main.py
+++ b/comercial-backend/main.py
@@ -1,6 +1,7 @@
 from fastapi import FastAPI, Request
 from fastapi.responses import JSONResponse
 from database import get_db_connection
+from datetime import datetime
 import re
 import json
 
@@ -57,13 +58,14 @@ async def criar_atendimento(request: Request):
             data.get("rt_percent"),
             data.get("historico"),
             json.dumps(data.get("arquivos", [])),
+            datetime.utcnow().isoformat(),
         )
         cur = conn.execute(
             """INSERT INTO atendimentos (
                 cliente, codigo, projetos, previsao_fechamento,
                 temperatura, tem_especificador, especificador_nome,
-                rt_percent, historico, arquivos_json
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                rt_percent, historico, arquivos_json, data_cadastro
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
             fields,
         )
         atendimento_id = cur.lastrowid
@@ -80,7 +82,7 @@ async def criar_atendimento(request: Request):
 async def listar_atendimentos():
     with get_db_connection() as conn:
         rows = conn.execute(
-            "SELECT id, cliente, codigo, previsao_fechamento, temperatura FROM atendimentos ORDER BY id DESC"
+            "SELECT id, cliente, codigo, previsao_fechamento, temperatura, data_cadastro FROM atendimentos ORDER BY id DESC"
         ).fetchall()
         itens = [dict(row) for row in rows]
     return {"atendimentos": itens}

--- a/frontend-erp/src/modules/Comercial/pages/AtendimentoDetalhes.jsx
+++ b/frontend-erp/src/modules/Comercial/pages/AtendimentoDetalhes.jsx
@@ -86,7 +86,7 @@ function TarefaItem({ tarefa, atendimentoId, onChange, projetos }) {
               <span>{amb}</span>
               <input type="file" accept=".xml,.txt,.csv" onChange={handleFile(amb)} />
             </div>
-            {dadosProj[amb] && (
+            {dadosProj[amb] && dadosProj[amb].valor > 0 && (
               <div className="text-sm text-gray-700 ml-2">
                 {dadosProj[amb].arquivo} - Valor: {dadosProj[amb].valor}
               </div>

--- a/frontend-erp/src/modules/Comercial/pages/Atendimentos.jsx
+++ b/frontend-erp/src/modules/Comercial/pages/Atendimentos.jsx
@@ -28,7 +28,7 @@ function Atendimentos() {
             const last = tarefas[lastDoneIndex];
             return {
               ...at,
-              dataCriacao: first?.dados?.data || '',
+              dataCadastro: at.data_cadastro || first?.dados?.data || '',
               setor: 'Comercial',
               status: next ? next.nome : 'Finalizado',
               ultimaAtualizacao: last?.dados?.data || '',
@@ -64,7 +64,7 @@ function Atendimentos() {
       <table className="w-full text-sm">
         <thead>
           <tr className="bg-gray-100">
-            <th className="border px-2">Data</th>
+            <th className="border px-2">Data de Cadastro</th>
             <th className="border px-2">Código</th>
             <th className="border px-2">Cliente</th>
             <th className="border px-2">Setor</th>
@@ -76,7 +76,7 @@ function Atendimentos() {
         <tbody>
           {atendimentos.map((at) => (
             <tr key={at.id}>
-              <td className="border px-2">{at.dataCriacao || '-'}</td>
+              <td className="border px-2">{at.dataCadastro || '-'}</td>
               <td className="border px-2">
                 <Link to={String(at.id)} className="hover:underline">
                   {at.codigo}


### PR DESCRIPTION
## Summary
- add `data_cadastro` column to comercial DB and migrations
- record creation date when inserting new atendimento
- expose `data_cadastro` in list endpoint
- show `Data de Cadastro` column in frontend
- hide zero values in Projeto 3D task display

## Testing
- `npm run lint` *(fails: no-unused-vars and formatting errors)*

------
https://chatgpt.com/codex/tasks/task_e_68617286c5e4832d8cf38fec5d261eb2