### PR TITLE
Fix data cadastro formatting

### DIFF
--- a/frontend-erp/src/modules/Comercial/pages/Atendimentos.jsx
+++ b/frontend-erp/src/modules/Comercial/pages/Atendimentos.jsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
 import { Button } from '../../Producao/components/ui/button';
 import { fetchComAuth } from '../../../utils/fetchComAuth';
+import { formatDateBr } from '../../../utils/formatDateBr';
 
 function Atendimentos() {
   const [atendimentos, setAtendimentos] = useState([]);
@@ -26,12 +27,14 @@ function Atendimentos() {
             const lastDoneIndex = tarefas.map((x) => Number(x.concluida)).lastIndexOf(1);
             const next = tarefas[lastDoneIndex + 1];
             const last = tarefas[lastDoneIndex];
+            const dataCadastroRaw = at.data_cadastro || first?.dados?.data || '';
+            const ultimaRaw = last?.dados?.data || '';
             return {
               ...at,
-              dataCadastro: at.data_cadastro || first?.dados?.data || '',
+              dataCadastro: formatDateBr(dataCadastroRaw),
               setor: 'Comercial',
               status: next ? next.nome : 'Finalizado',
-              ultimaAtualizacao: last?.dados?.data || '',
+              ultimaAtualizacao: formatDateBr(ultimaRaw),
             };
           } catch {
             return { ...at, setor: 'Comercial' };

--- a/frontend-erp/src/utils/formatDateBr.js
+++ b/frontend-erp/src/utils/formatDateBr.js
@@ -1,0 +1,7 @@
+export function formatDateBr(dateStr) {
+  if (!dateStr) return '';
+  const d = new Date(dateStr);
+  if (isNaN(d.getTime())) return dateStr;
+  return d.toLocaleDateString('pt-BR');
+}
+


### PR DESCRIPTION
## Summary
- add util to format dates in pt-BR
- format `dataCadastro` and `ultimaAtualizacao` in Brazilian format

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js' and multiple lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_6862770fac34832d9c69a4b485bc30c2